### PR TITLE
Fix debug middleware stuck bug

### DIFF
--- a/opium/debug.ml
+++ b/opium/debug.ml
@@ -16,7 +16,7 @@ let format_error req _exn = sprintf "
 
 let debug =
   let filter handler req =
-    try_with (fun () -> handler req) >>= function
+    Monitor.try_with ~run:`Now (fun () -> handler req) >>= function
     | Ok v -> return v
     | Error _exn ->
       exn_ _exn;                  (* log exception *)


### PR DESCRIPTION
There is a problem when I use `debug` middleware with handling `POST`.

The fix is just replacing `try_with` with `Monitor.try_with ~run:Now`.  I don't understand why this fix works.

See also:
https://github.com/mirage/ocaml-cohttp/issues/156
