### PR TITLE
Adding wildcard match to int_of_meth to catch non-standard http verbs an...

### DIFF
--- a/opium/router.ml
+++ b/opium/router.ml
@@ -19,6 +19,7 @@ let int_of_meth = function
   | `HEAD    -> 4
   | `PATCH   -> 5
   | `OPTIONS -> 6
+  | _ -> failwith("non standard http verbs not supported")
 
 let get t meth = t.(int_of_meth meth)
 


### PR DESCRIPTION
...d then fail
