### PR TITLE
Cohttp changed functions around authentication.

### DIFF
--- a/examples/auth_middleware.ml
+++ b/examples/auth_middleware.ml
@@ -30,7 +30,7 @@ let m auth =
     | None ->
       (* could redirect here, but we return user as an option type *)
       handler req
-    | Some (Cohttp.Auth.Basic (username, password)) ->
+    | Some (`Basic (username, password)) ->
       match auth ~username ~password with
       | None -> failwith "TODO: bad username/password pair"
       | Some user -> (* we have a user. let's add him to req *)


### PR DESCRIPTION
It looks like Cohttp changed the naming around the functions that they use for handling basic authentication.  It took some spelunking, but the final piece of evidence was found in a unit test:

https://github.com/mirage/ocaml-cohttp/commit/14a6528eb2a5a1af44704a57e2093336e985b0cc
