### PR TITLE
Adding functions to retrieve the contents of the body

### DIFF
--- a/opium/app.ml
+++ b/opium/app.ml
@@ -221,13 +221,13 @@ module Make (Router : App_intf.Router) = struct
       req |> Request.body |> Cohttp_async.Body.to_string >>| Json.of_string
     let string_exn req = 
       req |> Request.body |> Cohttp_async.Body.to_string
-    let list_exn req = 
+    let pairs_exn req = 
       req |> Request.body |> Cohttp_async.Body.to_string >>| Uri.query_of_encoded
   end
 
   let json_of_body_exn = Request_helpers.json_exn
   let string_of_body_exn = Request_helpers.string_exn
-  let list_of_body_exn = Request_helpers.list_exn
+  let urlencoded_pairs_of_body = Request_helpers.pairs_exn
   let param            = Router.param
   let splat            = Router.splat
   let respond          = Response_helpers.respond

--- a/opium/app_intf.mli
+++ b/opium/app_intf.mli
@@ -88,7 +88,7 @@ module type S = sig
 
   val string_of_body_exn : Request.t -> string Deferred.t
 
-  val list_of_body_exn : Request.t -> (string * string list) list Async_kernel.Deferred.t
+  val urlencoded_pairs_of_body : Request.t -> (string * string list) list Async_kernel.Deferred.t
 
   val param : Request.t -> string -> string
 


### PR DESCRIPTION
Adding functions to retrieve the contents of the body ( if properly encoded ) on a POST ( probably PUT, and PATCH but those are not tested ).

The _string_of_body_exn_ function returns the entire body as one string. 

The _list_of_body_exn_ returns a value similar to `[(key1, [v1;v2]);(key2, [x1])]`.
