### PR TITLE
Generate Content-Type headers for static file serving

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -41,7 +41,8 @@ Library opium
                 humane_re,
                 ezjsonm,
                 base64,
-                cmdliner
+                cmdliner,
+                magic-mime
 
 Executable test_routes
   Path:           lib_test

--- a/opam
+++ b/opam
@@ -40,6 +40,7 @@ depends: [
   "fieldslib"
   "sexplib"
   "humane-re"
+  "magic-mime"
   "ounit" {test}
   "cow" {test & >= "0.10.0"}
 ]

--- a/opium/static_serve.ml
+++ b/opium/static_serve.ml
@@ -21,7 +21,9 @@ let public_serve t ~requested =
   match legal_path t requested with
   | None -> return `Not_found
   | Some legal_path ->
-    Server.respond_file ~fname:legal_path () >>| fun resp ->
+    let mime_type = Magic_mime.lookup legal_path in
+    let headers = Cohttp.Header.init_with "content-type" mime_type in
+    Server.respond_file ~headers ~fname:legal_path () >>| fun resp ->
     if resp |> fst |> Cohttp.Response.status = `Not_found
     then `Not_found
     else `Ok (Response.of_response_body resp)

--- a/opium/static_serve.mli
+++ b/opium/static_serve.mli
@@ -1,3 +1,5 @@
-(** Middleware serves all fiels (recursively) in the [local_path] directory
-    under the [uri_prefix] url *)
+(** Middleware serves all files (recursively) in the [local_path] directory
+    under the [uri_prefix] url.  The responses contain a [Content-type]
+    header that is auto-detected based on the file extension using the
+    {!Magic_mime.lookup} function. *)
 val m : local_path:string -> uri_prefix:string -> Opium_rock.Middleware.t


### PR DESCRIPTION
This uses the `magic-mime` library to detect the filename and
generate a sensible MIME type from the `mime.types` database.
It is particularly important to generate these for Internet Explorer
support, since IE10 seems to ignore `.css` files that do not send
an appropriate MIME header.  With this patch, IE10 rendering works
great using an Opium rendering stack.