### PR TITLE
Add expiration parameter to cookies

### DIFF
--- a/opium/cookie.ml
+++ b/opium/cookie.ml
@@ -56,14 +56,14 @@ let set_cookies resp cookies =
 
 let set resp ~key ~data = set_cookies resp [(key, data)]
 
-let create_m ?(name = "Cookie") ?expiration () =             (* TODO: "optimize" *)
+let m =             (* TODO: "optimize" *)
   let filter handler req =
     handler req >>| fun response ->
     let cookie_headers =
       let module Cookie = Co.Cookie.Set_cookie_hdr in
       let f (k,v) =
         (keyc#encode k, valc#encode v)
-        |> Cookie.make ~path:"/" ?expiration
+        |> Cookie.make ~path:"/" 
         |> Cookie.serialize
       in current_cookies Rock.Response.Fields.env response |> List.map ~f in
     let old_headers = Rock.Response.headers response in
@@ -71,18 +71,4 @@ let create_m ?(name = "Cookie") ?expiration () =             (* TODO: "optimize"
        List.fold_left cookie_headers ~init:old_headers
          ~f:(fun headers (k,v) -> Co.Header.add headers k v))
     } 
-  in Rock.Middleware.create ~filter ~name:(Info.of_string name)
-
-let m = create_m ~name:"Session Cookie" ()
-
-let m_1d = create_m ~name:"1-day persistent Cookie"
-  ~expiration:(`Max_age 86400L) ()
-
-let m_1w = create_m ~name:"1-week persistent Cookie"
-  ~expiration:(`Max_age 604800L) ()
-
-let m_1m = create_m ~name:"1-month persistent Cookie"
-  ~expiration:(`Max_age 2592000L) ()
-
-let m_1y = create_m ~name:"1-year persistent Cookie"
-  ~expiration:(`Max_age 31536000L) ()
+  in Rock.Middleware.create ~filter ~name:(Info.of_string "Cookie")

--- a/opium/cookie.mli
+++ b/opium/cookie.mli
@@ -9,4 +9,14 @@ val set : Opium_rock.Response.t -> key:string -> data:string -> Opium_rock.Respo
 (** Like set but will do multiple cookies at once *)
 val set_cookies : Opium_rock.Response.t -> (string * string) list -> Opium_rock.Response.t
 (** Opium_rock middleware to add the the functionality above *)
+val create_m : ?name:string -> ?expiration:Cohttp.Cookie.expiration -> unit -> Opium_rock.Middleware.t
+(** Session cookie middleware *)
 val m : Opium_rock.Middleware.t
+(** 1-day persistent cookie middleware *)
+val m_1d : Opium_rock.Middleware.t
+(** 1-week persistent cookie middleware *)
+val m_1w : Opium_rock.Middleware.t
+(** 1-month persistent cookie middleware *)
+val m_1m : Opium_rock.Middleware.t
+(** 1-year persistent cookie middleware *)
+val m_1y : Opium_rock.Middleware.t

--- a/opium/cookie.mli
+++ b/opium/cookie.mli
@@ -5,8 +5,8 @@ val cookies : Opium_rock.Request.t -> (string * string) list
 (** Get the follow of a cookie with a certain key *)
 val get : Opium_rock.Request.t -> key:string -> string option
 (** Set the value of a cookie with a certain key in a response *)
-val set : Opium_rock.Response.t -> key:string -> data:string -> Opium_rock.Response.t
+val set : ?expiration:Cohttp.Cookie.expiration -> Opium_rock.Response.t -> key:string -> data:string -> Opium_rock.Response.t
 (** Like set but will do multiple cookies at once *)
-val set_cookies : Opium_rock.Response.t -> (string * string) list -> Opium_rock.Response.t
+val set_cookies : ?expiration:Cohttp.Cookie.expiration -> Opium_rock.Response.t -> (string * string) list -> Opium_rock.Response.t
 (** Opium_rock middleware to add the the functionality above *)
 val m : Opium_rock.Middleware.t

--- a/opium/cookie.mli
+++ b/opium/cookie.mli
@@ -9,14 +9,4 @@ val set : Opium_rock.Response.t -> key:string -> data:string -> Opium_rock.Respo
 (** Like set but will do multiple cookies at once *)
 val set_cookies : Opium_rock.Response.t -> (string * string) list -> Opium_rock.Response.t
 (** Opium_rock middleware to add the the functionality above *)
-val create_m : ?name:string -> ?expiration:Cohttp.Cookie.expiration -> unit -> Opium_rock.Middleware.t
-(** Session cookie middleware *)
 val m : Opium_rock.Middleware.t
-(** 1-day persistent cookie middleware *)
-val m_1d : Opium_rock.Middleware.t
-(** 1-week persistent cookie middleware *)
-val m_1w : Opium_rock.Middleware.t
-(** 1-month persistent cookie middleware *)
-val m_1m : Opium_rock.Middleware.t
-(** 1-year persistent cookie middleware *)
-val m_1y : Opium_rock.Middleware.t


### PR DESCRIPTION
This patch adds a `?expiration : Cohttp.Cookie.expiration` parameter to `Cookie.set` and `Cookie.set_cookies` functions.

This works by using a new Env for response cookies (before, the same Env than request cookies was uesd), with a cookie of type `(string * string * Cohttp.Cookie.expiration)`.

This patch doesn't break `Cookie` interface since the new parameter is optional, and default to `Session`.