### PR TITLE
Add SSL options to server

### DIFF
--- a/opium/app.ml
+++ b/opium/app.ml
@@ -6,6 +6,7 @@ open Rock
 
 type t = {
   port:        int;
+  ssl:         (string * string) option;
   debug:       bool;
   verbose:     bool;
   routes :     (Co.Code.meth * Route.t * Handler.t) list;
@@ -24,6 +25,7 @@ let register app ~meth ~route ~action =
 let empty =
   { name        = "Opium Default Name";
     port        = 3000;
+    ssl         = None;
     debug       = false;
     verbose     = false;
     routes      = [];
@@ -46,6 +48,7 @@ let attach_middleware { verbose ; debug ; routes ; middlewares ; _  } =
   ] |> List.filter_opt
 
 let port port t = { t with port }
+let ssl cert key t = { t with ssl = Some (cert, key) }
 let cmd_name name t = { t with name }
 
 let middleware m app =
@@ -96,8 +99,9 @@ let start app =
   Lwt_log.ign_info_f "Running on port: %d%s" app.port
     (if app.debug then " (debug)" else "");
   let port = app.port in
+  let ssl = app.ssl in
   let app = Rock.App.create ~middlewares ~handler:app.not_found in
-  app |> Rock.App.run ~port
+  app |> Rock.App.run ~port ~ssl
 
 let print_routes_f routes =
   let routes_tbl = Hashtbl.Poly.create () in
@@ -117,8 +121,10 @@ let print_middleware_f middlewares =
   |> List.map ~f:(Fn.compose Info.to_string_hum Rock.Middleware.name)
   |> List.iter ~f:(printf "> %s \n")
 
-let cmd_run app port host print_routes print_middleware debug verbose errors =
-  let app = { app with debug ; verbose ; port } in
+let cmd_run app port ssl_cert ssl_key host print_routes print_middleware
+    debug verbose errors =
+  let ssl = Option.map2 ssl_cert ssl_key (fun c k -> (c, k)) in
+  let app = { app with debug ; verbose ; port ; ssl } in
   let rock_app = to_rock app in
   (if print_routes then begin
      app |> routes |> print_routes_f;
@@ -143,6 +149,12 @@ module Cmds = struct
   let port default =
     let doc = "port" in
     Arg.(value & opt int default & info ["p"; "port"] ~doc)
+  let ssl_cert =
+    let doc = "SSL certificate file" in
+    Arg.(value & opt (some string) None & info ["s"; "ssl-cert"] ~doc)
+  let ssl_key =
+    let doc = "SSL key file" in
+    Arg.(value & opt (some string) None & info ["k"; "ssl-key"] ~doc)
   let interface =
     let doc = "interface" in
     Arg.(value & opt string "0.0.0.0" & info ["i"; "interface"] ~doc)
@@ -160,8 +172,8 @@ module Cmds = struct
     let open Cmdliner in
     let open Cmdliner.Term in
     fun app ->
-      pure cmd_run $ (pure app) $ port app.port $ interface $ routes
-      $ middleware $ debug $ verbose $ errors
+      pure cmd_run $ (pure app) $ port app.port $ ssl_cert $ ssl_key
+      $ interface $ routes $ middleware $ debug $ verbose $ errors
 
   let info name =
     let doc = sprintf "%s (Opium App)" name in

--- a/opium/app.mli
+++ b/opium/app.mli
@@ -21,6 +21,8 @@ type builder = t -> t with sexp_of
 
 val port : int -> builder
 
+val ssl : string -> string -> builder
+
 val cmd_name : string -> builder
 
 (** A route is a function that returns a buidler that hooks up a

--- a/opium/app.mli
+++ b/opium/app.mli
@@ -21,7 +21,7 @@ type builder = t -> t with sexp_of
 
 val port : int -> builder
 
-val ssl : string -> string -> builder
+val ssl : cert:string -> key:string -> builder
 
 val cmd_name : string -> builder
 

--- a/rock/opium_rock.ml
+++ b/rock/opium_rock.ml
@@ -108,9 +108,12 @@ module App = struct
 
   let create ?(middlewares=[]) ~handler = { middlewares; handler }
 
-  let run { handler; middlewares } ~port =
+  let run { handler; middlewares } ~port ~ssl =
     let middlewares = middlewares |> List.map ~f:Middleware.filter in
-    Server.create ~mode:(`TCP (`Port port)) (
+    let mode = Option.value_map ssl
+      ~default:(`TCP (`Port port)) ~f:(fun (c, k) ->
+        `TLS (`Crt_file_path c, `Key_file_path k, `No_password, `Port port)) in
+    Server.create ~mode (
       Server.make ~callback:(fun _ req body ->
         let req = Request.create ~body req in
         let handler = Filter.apply_all middlewares handler in

--- a/rock/opium_rock.ml
+++ b/rock/opium_rock.ml
@@ -108,11 +108,11 @@ module App = struct
 
   let create ?(middlewares=[]) ~handler = { middlewares; handler }
 
-  let run { handler; middlewares } ~port ~ssl =
+  let run ?ssl { handler; middlewares } ~port =
     let middlewares = middlewares |> List.map ~f:Middleware.filter in
     let mode = Option.value_map ssl
       ~default:(`TCP (`Port port)) ~f:(fun (c, k) ->
-        `TLS (`Crt_file_path c, `Key_file_path k, `No_password, `Port port)) in
+        `TLS (c, k, `No_password, `Port port)) in
     Server.create ~mode (
       Server.make ~callback:(fun _ req body ->
         let req = Request.create ~body req in

--- a/rock/opium_rock.mli
+++ b/rock/opium_rock.mli
@@ -105,5 +105,5 @@ module App : sig
 
   val create : ?middlewares:Middleware.t list -> handler:Handler.t -> t
 
-  val run : t -> port:int -> unit Lwt.t
+  val run : t -> port:int -> ssl:((string * string) option) -> unit Lwt.t
 end

--- a/rock/opium_rock.mli
+++ b/rock/opium_rock.mli
@@ -105,5 +105,5 @@ module App : sig
 
   val create : ?middlewares:Middleware.t list -> handler:Handler.t -> t
 
-  val run : t -> port:int -> ssl:((string * string) option) -> unit Lwt.t
+  val run : ?ssl:[ `Crt_file_path of string ] * [ `Key_file_path of string ] -> t -> port:int -> unit Lwt.t
 end


### PR DESCRIPTION
This patch adds the following options to enable SSL when starting the server:

```
-s VAL, --ssl-cert=VAL
SSL certificate file

-k VAL, --ssl-key=VAL
SSL key file
```