### PR TITLE
remove core_kernel

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -6,11 +6,12 @@ S examples
 B _build/**
 
 PKG base64
-PKG core_kernel
 PKG lwt
 PKG lwt.unix
 PKG cohttp.lwt
 PKG cmdliner
+PKG uri
+PKG sexplib
 PKG oUnit
 PKG ezjsonm
 PKG sexplib.syntax

--- a/OMakefile
+++ b/OMakefile
@@ -35,7 +35,7 @@ OCAMLFLAGS = -g -bin-annot -thread
 
 OCAMLFINDFLAGS += -syntax camlp4o
 OCAMLPACKS[] +=
-    core_kernel
+    # core_kernel
     cohttp.lwt-core
     camlp4
     fieldslib.syntax

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Here's a simple hello world example to get your feet wet:
 `$ cat hello_world.ml`
 
 ``` ocaml
-open Core_kernel.Std
 open Opium.Std
 
 type person = {
@@ -74,7 +73,7 @@ end
 let print_person = get "/person/:name/:age" begin fun req ->
   let person = {
     name = param req "name";
-    age = "age" |> param req |> Int.of_string;
+    age = "age" |> param req |> int_of_string;
   } in
   `Json (person |> json_of_person |> Ezjsonm.wrap) |> respond'
 end
@@ -107,8 +106,9 @@ Here's how you'd create a simple middleware turning away everyone's
 favourite browser.
 
 ``` ocaml
-open Core_kernel.Std
 open Opium.Std
+open Opium_misc
+
 (* don't open cohttp and opium since they both define
    request/response modules*)
 
@@ -121,7 +121,7 @@ let reject_ua ~f =
     | Some ua when f ua ->
       `String ("Please upgrade your browser") |> respond'
     | _ -> handler req in
-  Rock.Middleware.create ~filter ~name:(Info.of_string "reject_ua")
+  Rock.Middleware.create ~filter ~name:"reject_ua"
 
 let _ = App.empty
         |> get "/" (fun req -> `String ("Hello World") |> respond')

--- a/examples/auth_middleware.ml
+++ b/examples/auth_middleware.ml
@@ -1,5 +1,8 @@
-open Core_kernel.Std
+
 open Opium.Std
+open Sexplib.Std
+
+module Univ_map = Opium_umap.Default
 
 type user = {
   username: string;
@@ -12,7 +15,7 @@ type user = {
 module Env = struct
   (* or use type nonrec *)
   type user' = user
-  let key : user' Univ_map.Key.t = Univ_map.Key.create "user" <:sexp_of<user>>
+  let key : user' Univ_map.Key.t = Univ_map.Key.create ("user",<:sexp_of<user>>)
 end
 
 (*
@@ -36,10 +39,10 @@ let m auth =
       match auth ~username ~password with
       | None -> failwith "TODO: bad username/password pair"
       | Some user -> (* we have a user. let's add him to req *)
-        let env = Univ_map.add_exn (Request.env req) Env.key user in
-        let req = Field.fset Request.Fields.env req env in
+        let env = Univ_map.add Env.key user (Request.env req) in
+        let req = {req with Request.env = env; } in
         handler req
   in
-  Rock.Middleware.create ~name:(Info.of_string "http basic auth") ~filter
+  Rock.Middleware.create ~name:"http basic auth" ~filter
 
-let user req = Univ_map.find (Request.env req) Env.key
+let user req = Univ_map.find Env.key (Request.env req)

--- a/examples/exit_hook_example.ml
+++ b/examples/exit_hook_example.ml
@@ -1,5 +1,5 @@
 (* How to clean up and exit an opium app *)
-open Core_kernel.Std
+
 open Opium.Std
 
 let hello = get "/" (fun req -> `String "Hello World" |> respond')

--- a/examples/hello_world.ml
+++ b/examples/hello_world.ml
@@ -1,4 +1,3 @@
-open Core_kernel.Std
 open Opium.Std
 
 type person = {
@@ -18,7 +17,7 @@ end
 let print_person = get "/person/:name/:age" begin fun req ->
   let person = {
     name = param req "name";
-    age = "age" |> param req |> Int.of_string;
+    age = "age" |> param req |> int_of_string;
   } in
   `Json (person |> json_of_person |> Ezjsonm.wrap) |> respond'
 end

--- a/examples/hello_world_basic.ml
+++ b/examples/hello_world_basic.ml
@@ -1,4 +1,3 @@
-open Core_kernel.Std
 open Opium.Std
 
 let hello = get "/" (fun req -> `String "Hello World" |> respond')

--- a/examples/hello_world_html.ml
+++ b/examples/hello_world_html.ml
@@ -1,4 +1,3 @@
-open Core_kernel.Std
 open Opium.Std
 open Cow
 

--- a/examples/middleware_ua.ml
+++ b/examples/middleware_ua.ml
@@ -1,5 +1,6 @@
-open Core_kernel.Std
 open Opium.Std
+open Opium_misc
+
 (* don't open cohttp and opium since they both define
    request/response modules*)
 
@@ -12,7 +13,7 @@ let reject_ua ~f =
     | Some ua when f ua ->
       `String ("Please upgrade your browser") |> respond'
     | _ -> handler req in
-  Rock.Middleware.create ~filter ~name:(Info.of_string "reject_ua")
+  Rock.Middleware.create ~filter ~name:"reject_ua"
 
 let _ = App.empty
         |> get "/" (fun req -> `String ("Hello World") |> respond')

--- a/examples/read_json_body.ml
+++ b/examples/read_json_body.ml
@@ -1,4 +1,3 @@
-open Core_kernel.Std
 open Opium.Std
 
 let print_json req =

--- a/examples/sample.ml
+++ b/examples/sample.ml
@@ -1,5 +1,5 @@
-open Core_kernel.Std
 open Opium.Std
+
 let e1 = get "/version" (fun req -> (`String "testing") |> respond')
 
 let e2 = get "/hello/:name" (fun req -> 
@@ -8,15 +8,15 @@ let e2 = get "/hello/:name" (fun req ->
 
 let e3 = get "/xxx/:x/:y" begin fun req ->
   let open Cow.Json in
-  let x = "x" |> param req |> Int.of_string in
-  let y = "y" |> param req |> Int.of_string in
-  let sum = Float.of_int (x + y) in
+  let x = "x" |> param req |> int_of_string in
+  let y = "y" |> param req |> int_of_string in
+  let sum = float_of_int (x + y) in
   `Json (`A [int x; int y;float sum]) |> respond'
 end
 
 let e4 = put "/hello/:x/from/:y" begin fun req ->
   let (x,y) = (param req "x", param req "y") in
-  let msg = sprintf "Hello %s! from %s." x y in
+  let msg = Printf.sprintf "Hello %s! from %s." x y in
   `String msg |> respond |> return
 end
 
@@ -31,14 +31,14 @@ end
 let get_cookie = get "/get/:key" begin fun req ->
   Lwt_log.ign_info "Getting cookie";
   let key = param req "key" in
-  let message = sprintf "Cookie %s doesn't exist" key in
+  let message = Printf.sprintf "Cookie %s doesn't exist" key in
   let value = Option.value_exn ~message (Cookie.get req ~key) in
-  `String (sprintf "Cookie %s is: %s" key value) |> respond |> return
+  `String (Printf.sprintf "Cookie %s is: %s" key value) |> respond |> return
 end
 
 let splat_route = get "/testing/*/:p" begin fun req ->
   let p = param req "p" in
-  `String (sprintf "__ %s __" p ^ (req |> splat |> String.concat ~sep:":"))
+  `String (Printf.sprintf "__ %s __" p ^ (req |> splat |> String.concat ":"))
   |> respond'
 end
 
@@ -46,9 +46,9 @@ let all_cookies = get "/cookies" begin fun req ->
   let cookies = req
                 |> Cookie.cookies
                 |> List.map ~f:(fun (k,v) -> k ^ "=" ^ v)
-                |> String.concat ~sep:"\n"
+                |> String.concat "\n"
   in
-  `String (sprintf "<pre>%s</pre>" cookies) |> respond |> return
+  `String (Printf.sprintf "<pre>%s</pre>" cookies) |> respond |> return
 end
 
 (* exceptions should be nicely formatted *)

--- a/examples/static_serve_override.ml
+++ b/examples/static_serve_override.ml
@@ -6,7 +6,7 @@
    The result will be the corresponding file in ./examples/ rather than the
    string "hello_world".
 *)
-open Core_kernel.Std
+
 open Opium.Std
 
 let hello = get "/examples/hello_world.ml" (fun req ->

--- a/examples/uppercase_middleware.ml
+++ b/examples/uppercase_middleware.ml
@@ -1,4 +1,3 @@
-open Core_kernel.Std
 open Opium.Std
 
 let uppercase =
@@ -7,9 +6,9 @@ let uppercase =
       response
       |> Response.body
       |> Cohttp_lwt_body.map String.uppercase
-      |> Field.fset Response.Fields.body response)
+      |> (fun b->{response with Response.body=b; }))
   in
-  Rock.Middleware.create ~name:(Info.of_string "uppercaser") ~filter
+  Rock.Middleware.create ~name:"uppercaser" ~filter
 
 let _ = App.empty
         |> middleware uppercase

--- a/lib_test/routes.ml
+++ b/lib_test/routes.ml
@@ -1,4 +1,6 @@
-open Core_kernel.Std
+open Opium_misc
+open Sexplib
+open Sexplib.Std
 open OUnit
 
 module Route = Opium_kernel.Route
@@ -11,7 +13,7 @@ let string_of_match = function
   | Some m ->
     Sexp.to_string_hum
       (List.sexp_of_t
-         (Tuple.T2.sexp_of_t String.sexp_of_t String.sexp_of_t) m)
+         (sexp_of_pair sexp_of_string sexp_of_string) m)
 
 let simple_route1 _ =
   let r = Route.of_string "/test/:id" in
@@ -25,8 +27,8 @@ let simple_route2 _ =
   match m with
   | None -> assert_failure "no matches"
   | Some s -> begin
-      assert_equal (List.Assoc.find_exn s "format") "json";
-      assert_equal (List.Assoc.find_exn s "name") "bar"
+      assert_equal (List.assoc "format" s) "json";
+      assert_equal (List.assoc "name" s) "bar"
     end
 
 let simple_route3 _ =
@@ -57,8 +59,8 @@ let test_match_2_params _ =
   match m with
   | None -> assert_failure "no match found"
   | Some m -> begin
-      assert_equal (List.Assoc.find_exn m "x") "123";
-      assert_equal (List.Assoc.find_exn m "y") "456"
+      assert_equal (List.assoc "x" m) "123";
+      assert_equal (List.assoc "y" m) "456"
     end
 
 let test_match_no_param _ =

--- a/opium/opium_app.mli
+++ b/opium/opium_app.mli
@@ -5,7 +5,6 @@
     - Easy handling of routes and bodies
     - Automatic generation of a command line app
 *)
-open Core_kernel.Std
 open Opium_kernel.Rock
 
 (** An opium app is a simple builder wrapper around a rock app *)

--- a/opium/opium_debug.ml
+++ b/opium/opium_debug.ml
@@ -1,16 +1,15 @@
-open Core_kernel.Std
 open Opium_misc
 open Opium_rock
 
-let exn_ e = Lwt_log.ign_error_f "%s" (Exn.to_string e)
+let exn_ e = Lwt_log.ign_error_f "%s" (Printexc.to_string e)
 
-let format_error req _exn = sprintf "
+let format_error req _exn = Printf.sprintf "
 <html>
   <body>
   <div id=\"request\"><pre>%s</pre></div>
   <div id=\"error\"><pre>%s</pre></div>
   </body>
-</html>" (req |> Request.sexp_of_t |> Sexp.to_string_hum) (Exn.to_string _exn)
+</html>" (req |> Request.sexp_of_t |> Sexplib.Sexp.to_string_hum) (Printexc.to_string _exn)
 
 let debug =
   let filter handler req =
@@ -18,7 +17,7 @@ let debug =
       exn_ _exn;
       let body = format_error req _exn in
       Response.of_string_body ~code:`Internal_server_error body |> return)
-  in Middleware.create ~name:(Info.of_string "Debug") ~filter
+  in Middleware.create ~name:"Debug" ~filter
 
 let trace =
   let filter handler req =
@@ -26,4 +25,4 @@ let trace =
     let code = response |> Response.code |> Cohttp.Code.code_of_status in
     Lwt_log.ign_debug_f "Responded with %d" code;
     response
-  in Middleware.create ~name:(Info.of_string "Trace") ~filter
+  in Middleware.create ~name:"Trace" ~filter

--- a/opium/opium_static_serve.ml
+++ b/opium/opium_static_serve.ml
@@ -1,5 +1,5 @@
-open Core_kernel.Std
 open Opium_misc
+open Sexplib.Std
 
 module Server = Cohttp_lwt_unix.Server
 module Rock = Opium_rock
@@ -12,11 +12,10 @@ type t = {
 
 let legal_path {prefix;local_path} requested =
   let open Option in
-  String.chop_prefix requested ~prefix >>= fun p ->
-  let requested_path = Filename.concat local_path p
-  in Option.some_if
-       (String.is_prefix requested_path ~prefix:local_path)
-       requested_path
+  let p = String.chop_prefix requested ~prefix in
+  let requested_path = Filename.concat local_path p in
+  if String.is_prefix requested_path ~prefix:local_path
+  then Some requested_path else None
 
 let public_serve t ~requested =
   match legal_path t requested with
@@ -42,4 +41,4 @@ let m ~local_path ~uri_prefix =
         handler req
     else
       handler req
-  in Rock.Middleware.create ~name:(Info.of_string "Static Pages") ~filter
+  in Rock.Middleware.create ~name:"Static Pages" ~filter

--- a/opium_kernel/opium_cookie.mli
+++ b/opium_kernel/opium_cookie.mli
@@ -1,12 +1,20 @@
-(** Simple cookie module.  Cookies are base64'd and percent encoded.
-*)
+(** Simple cookie module.  Cookies are base64'd and percent encoded. *)
+
 (** Fetch all cookies from a rock request *)
 val cookies : Opium_rock.Request.t -> (string * string) list
+
 (** Get the follow of a cookie with a certain key *)
 val get : Opium_rock.Request.t -> key:string -> string option
+
 (** Set the value of a cookie with a certain key in a response *)
-val set : ?expiration:Cohttp.Cookie.expiration -> Opium_rock.Response.t -> key:string -> data:string -> Opium_rock.Response.t
+val set :
+  ?expiration:Cohttp.Cookie.expiration ->
+  Opium_rock.Response.t -> key:string -> data:string -> Opium_rock.Response.t
+
 (** Like set but will do multiple cookies at once *)
-val set_cookies : ?expiration:Cohttp.Cookie.expiration -> Opium_rock.Response.t -> (string * string) list -> Opium_rock.Response.t
+val set_cookies :
+  ?expiration:Cohttp.Cookie.expiration -> Opium_rock.Response.t ->
+    (string * string) list -> Opium_rock.Response.t
+
 (** Opium_rock middleware to add the the functionality above *)
 val m : Opium_rock.Middleware.t

--- a/opium_kernel/opium_misc.ml
+++ b/opium_kernel/opium_misc.ml
@@ -13,9 +13,13 @@ end
 
 module Option = struct
   let some x = Some x
+  let is_some = function Some _ -> true | None -> false
   let value ~default = function
     | Some x -> x
     | None -> default
+  let value_exn ~message = function
+    | Some x -> x
+    | None -> failwith message
   let map ~f = function
     | None -> None
     | Some x -> Some (f x)
@@ -66,6 +70,26 @@ module String = struct
   let chop_prefix ~prefix s =
     assert (is_prefix ~prefix s);
     sub s (length prefix) (length s - length prefix)
+
+  let _is_sub ~sub i s j ~len =
+    let rec check k =
+      if k = len
+        then true
+        else sub.[i+k] = s.[j+k] && check (k+1)
+    in
+    j+len <= String.length s && check 0
+
+  (* note: inefficient *)
+  let substr_index ~pattern:sub s =
+    let n = String.length sub in
+    let i = ref 0 in
+    try
+      while !i + n <= String.length s do
+        if _is_sub ~sub 0 s !i ~len:n then raise Exit;
+        incr i
+      done;
+      None
+    with Exit -> Some !i
 end
 
 module Queue = struct

--- a/opium_kernel/opium_misc.ml
+++ b/opium_kernel/opium_misc.ml
@@ -1,5 +1,99 @@
+open Sexplib
+
 let return = Lwt.return
 let (>>=) = Lwt.(>>=)
 let (>>|) = Lwt.(>|=)
 
 module Body = Cohttp_lwt_body
+
+module Fn = struct
+  let compose f g x = f (g x)
+  let const x _ = x
+end
+
+module Option = struct
+  let some x = Some x
+  let value ~default = function
+    | Some x -> x
+    | None -> default
+  let map ~f = function
+    | None -> None
+    | Some x -> Some (f x)
+  let map2 ~f a b = match a,b with
+    | Some x, Some y -> Some (f x y)
+    | _ -> None
+  let value_map ~default ~f = function
+    | None -> default
+    | Some x -> f x
+  let try_with f =
+    try Some (f ())
+    with _ -> None
+end
+
+module List = struct
+  include ListLabels
+
+  let rec filter_map ~f = function
+    | [] -> []
+    | x :: l ->
+        let l' = filter_map ~f l in
+        match f x with
+        | None -> l'
+        | Some y -> y :: l'
+  let is_empty = function [] -> true | _::_ -> false
+  let rec find_map ~f = function
+    | [] -> None
+    | x :: l ->
+        match f x with
+        | Some _ as res -> res
+        | None -> find_map ~f l
+  let rec filter_opt = function
+    | [] -> []
+    | None :: l -> filter_opt l
+    | Some x :: l -> x :: filter_opt l
+  let sexp_of_t sexp_of_elem l = Sexp.List (map l ~f:sexp_of_elem)
+end
+
+module String = struct
+  include String
+
+  let is_prefix ~prefix s =
+    String.length prefix <= String.length s &&
+    (let i = ref 0 in
+      while !i < String.length prefix && s.[!i] = prefix.[!i] do incr i done;
+      !i = String.length prefix)
+
+  let chop_prefix ~prefix s =
+    assert (is_prefix ~prefix s);
+    sub s (length prefix) (length s - length prefix)
+end
+
+module Queue = struct
+  include Queue
+
+  let find_map (type res) ~f q =
+    let module M = struct exception E of res end in
+    try
+      Queue.iter
+        (fun x -> match f x with None -> () | Some y -> raise (M.E y))
+        q;
+      None
+    with M.E res -> Some res
+
+  let t_of_sexp elem_of_sexp s = match s with
+    | Sexp.List l ->
+        let q = create () in
+        List.iter (fun x -> push (elem_of_sexp x) q) l;
+        q
+    | Sexp.Atom _ -> raise (Conv.Of_sexp_error (Failure "expected list", s))
+
+  let sexp_of_t sexp_of_elem q =
+    let l = Queue.fold (fun acc x -> sexp_of_elem x :: acc) [] q in
+    Sexp.List (List.rev l)
+end
+
+let sexp_of_pair f1 f2 (x1,x2) = Sexp.List [f1 x1; f2 x2]
+
+let hashtbl_add_multi tbl x y =
+  let l = try Hashtbl.find tbl x with Not_found -> [] in
+  Hashtbl.replace tbl x (y::l)

--- a/opium_kernel/opium_rock.mli
+++ b/opium_kernel/opium_rock.mli
@@ -3,8 +3,6 @@
     this to for such a tiny framework but it makes extensions a lot
     more straightforward *)
 
-open Core_kernel.Std
-
 (** A service is simply a function that returns it's result
     asynchronously *)
 module Service : sig
@@ -40,11 +38,11 @@ module Request : sig
   type t = {
     request: Cohttp.Request.t;
     body:    Cohttp_lwt_body.t;
-    env:     Univ_map.t;
+    env:     Opium_umap.Default.t;
   } with fields, sexp_of
 
   val create : ?body:Cohttp_lwt_body.t
-    -> ?env:Univ_map.t
+    -> ?env:Opium_umap.Default.t
     -> Cohttp.Request.t -> t
   (** Convenience accessors on the request field  *)
   val uri : t -> Uri.t
@@ -57,18 +55,18 @@ module Response : sig
     code:    Cohttp.Code.status_code;
     headers: Cohttp.Header.t;
     body:    Cohttp_lwt_body.t;
-    env:     Univ_map.t
+    env:     Opium_umap.Default.t
   } with fields, sexp_of
 
   val create :
-    ?env: Univ_map.t ->
+    ?env: Opium_umap.Default.t ->
     ?body:Cohttp_lwt_body.t ->
     ?headers:Cohttp.Header.t ->
     ?code:Cohttp.Code.status_code ->
     unit -> t
 
   val of_string_body :
-    ?env: Univ_map.t ->
+    ?env: Opium_umap.Default.t ->
     ?headers:Cohttp.Header.t ->
     ?code:Cohttp.Code.status_code ->
     string -> t
@@ -90,10 +88,10 @@ module Middleware : sig
 
   val filter : t -> (Request.t, Response.t) Filter.simple
 
-  val name : t -> Info.t
+  val name : t -> string
 
   val create : filter:(Request.t, Response.t) Filter.simple
-    -> name:Info.t -> t
+    -> name:string -> t
 end
 
 module App : sig

--- a/opium_kernel/opium_route.ml
+++ b/opium_kernel/opium_route.ml
@@ -1,4 +1,5 @@
-open Core_kernel.Std
+open Opium_misc
+open Sexplib.Std (* for the `with sexp` *)
 
 type path_segment =
   | Match of string
@@ -20,9 +21,8 @@ let parse_param s =
   else if s = "*" then Splat
   else if s = "**" then FullSplat
   else
-    match String.chop_prefix s ~prefix:":" with
-    | Some s -> Param s
-    | None -> Match s
+    try Scanf.sscanf s ":%s" (fun s -> Param s)
+    with Scanf.Scan_failure _ -> Match s
 
 let of_list l = 
   let last_i = List.length l - 1 in
@@ -57,7 +57,7 @@ let to_string l =
       | Splat     -> Some "*"
       | FullSplat -> Some "**"
       | Slash     -> None)
-    |> String.concat ~sep:"/" in
+    |> String.concat "/" in
   "/" ^ r
 
 let rec match_url t url ({params; splat} as matches) =

--- a/opium_kernel/opium_umap.ml
+++ b/opium_kernel/opium_umap.ml
@@ -1,0 +1,142 @@
+
+(** Universal map (currently embedded in opium, might move into opam)
+    Initial implementation by Daniel Bünzli
+
+    A dictionary is a set of {{!keys}keys} mapping to typed values. *)
+
+module type DICT = sig
+  type 'a user_data
+  (** User-specified data embedded into keys *)
+
+  (** {1:keys Keys} *)
+
+  module Key : sig
+    type 'a t
+    (** The type for dictionary keys whose lookup value is ['a]. *)
+
+    val create : 'a user_data -> 'a t
+    (** [create d] is a new dictionary key with [d] as embedded user data. *)
+
+    val user_data : 'a t -> 'a user_data
+    (** Extract user data from a key *)
+  end
+
+    (** {1:dict Dictionaries} *)
+
+  type t
+  (** The type for dictionaries. *)
+
+  val empty : t
+  (** [empty] is the empty dictionary. *)
+
+  val is_empty : t -> bool
+  (** [is_empty d] is [true] iff [d] is empty. *)
+
+  val mem : 'a Key.t -> t -> bool
+  (** [mem k d] is [true] iff [k] has a mapping in [d]. *)
+
+  val add : 'a Key.t -> 'a -> t -> t
+  (** [add k v d] is [d] with [k] mapping to [v]. *)
+
+  val rem : 'a Key.t -> t -> t
+  (** [rem k d] is [d] with [k] unbound. *)
+
+  val find_exn : 'a Key.t -> t -> 'a
+  (** [find d k] is [k]'s mapping in [d], if any.
+      @raise Not_found if the key is not present *)
+
+  val find : 'a Key.t -> t -> 'a option
+  (** [find d k] is [k]'s mapping in [d], if any. *)
+
+  val get : 'a Key.t -> t -> 'a
+  (** [get k d] is [k]'s mapping in [d].
+
+      {b Raises.} [Invalid_argument] if [k] is not bound in [d]. *)
+
+  type pair = Pair : 'a Key.t * 'a -> pair
+
+  val fold : ('a -> pair -> 'a) -> 'a -> t -> 'a
+end
+
+module Make(D : sig type _ t end)
+: DICT with type 'a user_data = 'a D.t
+= struct
+  type 'a user_data = 'a D.t
+
+  (* Dictionaries see http://mlton.org/PropertyList *)
+
+  (* Keys *)
+
+  module Key = struct
+    let univ (type s) () =
+      let module M = struct exception E of s end in
+      (fun x -> M.E x), (function M.E x -> x | _ -> raise Not_found)
+
+    let key_id =
+      let count = ref (-1) in
+      fun () -> incr count; !count
+
+    type 'a t =
+      { id : int;
+        name : string;
+        data : 'a user_data;
+        to_univ : 'a -> exn;
+        of_univ : exn -> 'a; }
+
+    let create data (type v) =
+      let id = key_id () in
+      let to_univ, of_univ = univ () in
+      { id; data; name = ""; to_univ; of_univ }
+
+    let user_data k = k.data
+
+    type boxed = V : 'a t -> boxed
+    let compare (V k0) (V k1) = (compare : int -> int -> int) k0.id k1.id
+  end
+
+  (* Dictionaries *)
+
+  module M = Map.Make(struct
+    type t = Key.boxed
+    let compare = Key.compare
+  end)
+  type t = exn M.t
+
+  let empty = M.empty
+  let is_empty = M.is_empty
+  let mem k d = M.mem (Key.V k) d
+  let add k v d  = M.add (Key.V k) (k.Key.to_univ v) d
+  let rem k d = M.remove (Key.V k) d
+  let find k d = try Some (k.Key.of_univ (M.find (Key.V k) d)) with Not_found -> None
+  let find_exn k d = k.Key.of_univ (M.find (Key.V k) d)
+  let get k d = match find k d with
+    | Some v -> v
+    | None -> invalid_arg "key unbound in dictionary"
+
+  type pair = Pair : 'a Key.t * 'a -> pair
+
+  let fold (type acc) f acc m =
+    let f'
+      : Key.boxed -> exn -> acc -> acc 
+      = fun (Key.V k) e acc ->
+        let v = k.Key.of_univ e in
+        f acc (Pair (k,v))
+    in
+    M.fold f' m acc
+end
+
+module Default = struct
+  include Make(struct
+    type 'a t = string * ('a -> Sexplib.Sexp.t)
+  end)
+
+  let sexp_of_t m =
+    let open Sexplib.Sexp in
+    let l = fold
+      (fun l (Pair (k,v)) ->
+        let name, to_sexp = Key.user_data k in
+        List [Atom name; to_sexp v] :: l)
+      [] m
+    in
+    List l
+end


### PR DESCRIPTION
This is currently *work in progress*, do not merge yet. Purpose: solve #40.

I added a `opium_kernel/opium_umap` (temporarily) to discuss the API and get one that works sufficiently well. We will fork it into its own library once we reach agreement on its interface (it is already a functor).

`Opium_misc`  now contains some utils to replace parts of `core_kernel` (missing functions, etc.). I also removed the `Info` stuff and replaced it with mere strings. I kept the sexplib stuff (a bit annoying to rewrite though). Tests do not compile yet.