### PR TITLE
enable ssl when it's set only through api but not cli

### DIFF
--- a/opium/opium_app.ml
+++ b/opium/opium_app.ml
@@ -135,7 +135,7 @@ let print_routes_f routes =
         (data
          |> List.map ~f:Cohttp.Code.string_of_method
          |> String.concat " "))
-    routes_tbl 
+    routes_tbl
 
 let print_middleware_f middlewares =
   print_endline "Active middleware:";
@@ -145,8 +145,13 @@ let print_middleware_f middlewares =
 
 let cmd_run app port ssl_cert ssl_key host print_routes print_middleware
     debug verbose errors =
-  let ssl = Option.map2 ssl_cert ssl_key ~f:(fun c k ->
-    (`Crt_file_path c, `Key_file_path k)) in
+  let ssl =
+    let cmd_ssl = Option.map2 ssl_cert ssl_key ~f:(fun c k ->
+      (`Crt_file_path c, `Key_file_path k)) in
+    match cmd_ssl, app.ssl with
+    | Some s, _ | None, Some s -> Some s
+    | None, None -> None
+  in
   let app = { app with debug ; verbose ; port ; ssl } in
   let rock_app = to_rock app in
   (if print_routes then begin
@@ -271,4 +276,3 @@ let respond                  = Response_helpers.respond
 let respond'                 = Response_helpers.respond'
 let redirect                 = Response_helpers.redirect
 let redirect'                = Response_helpers.redirect'
-


### PR DESCRIPTION
Command line options about ssl will always write over `app.ssl`. So when it has already been set by `App.ssl` function call, but not given any information through command line, the ssl will not be enabled (evaluated to `None` eventually).

In this patch, preference is given to command line option when both are not `None`.