### PR TITLE
Do not use or assume Base 64 encoding of cookies

### DIFF
--- a/opium_kernel/cookie.mli
+++ b/opium_kernel/cookie.mli
@@ -1,4 +1,4 @@
-(** Simple cookie module.  Cookies are base64'd and percent encoded. *)
+(** Simple cookie module.  Cookie values are percent encoded. *)
 
 (** Fetch all cookies from a rock request *)
 val cookies : Rock.Request.t -> (string * string) list


### PR DESCRIPTION
Also, only cookie values should be percent-decoded. The keys should be
using the safe alphabet as per the spec.

This fixes issue #57.