### PR TITLE
Add lwt_log to dependencies

### DIFF
--- a/examples/sample.ml
+++ b/examples/sample.ml
@@ -74,7 +74,7 @@ let app =
   |> all_cookies
   |> throws
   |> middleware Cookie.m
-  |> middleware (Middleware.static ~local_path:"./" ~uri_prefix:"/public")
+  |> middleware (Middleware.static ~local_path:"./" ~uri_prefix:"/public" ())
   |> splat_route
 
 let _ =

--- a/opium.opam
+++ b/opium.opam
@@ -19,6 +19,7 @@ depends: [
   "cohttp-lwt-unix" {>= "0.99.0"}
   "base-unix"
   "lwt"
+  "lwt_log"
   "cmdliner"
   "ppx_fields_conv" {>= "v0.9.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/opium/jbuild
+++ b/opium/jbuild
@@ -7,6 +7,7 @@
   (preprocess (pps (ppx_sexp_conv ppx_fields_conv)))
   (libraries
    (opium_kernel
+    lwt_log
     cmdliner
     cohttp-lwt-unix
     magic-mime


### PR DESCRIPTION
Lwt_log is deleted from lwt >= 4.0.0, adding lwt_log to the dependencies allows opium to compile with lwt 4.1.0.