### PR TITLE
Expose all cookie directives

### DIFF
--- a/opium_kernel/cookie.ml
+++ b/opium_kernel/cookie.ml
@@ -53,11 +53,12 @@ let get req ~key =
     |> List.find_map ~f:(fun (k,v) ->
       if k = key then Some (decode v) else None)
 
-let set_cookies ?expiration ?path ?domain ?secure ?http_only resp cookies =
+(* Path defaulted to "/" as otherwise the default is the path of the request's URI *)
+let set_cookies ?expiration ?(path = "/") ?domain ?secure ?http_only resp cookies =
   let env = Rock.Response.env resp in
   let current_cookies = current_cookies_resp (fun r->r.Rock.Response.env) resp in
   let cookies' = List.map cookies ~f:(fun (key, data) ->
-    Co.Cookie.Set_cookie_hdr.make ?path ?domain ?expiration ?secure ?http_only (key, encode data)) in
+    Co.Cookie.Set_cookie_hdr.make ~path ?domain ?expiration ?secure ?http_only (key, encode data)) in
   (* WRONG cookies cannot just be concatenated *)
   let all_cookies = current_cookies @ cookies' in
   { resp with Rock.Response.env=(Hmap0.add Env_resp.key all_cookies env) }

--- a/opium_kernel/cookie.mli
+++ b/opium_kernel/cookie.mli
@@ -9,6 +9,10 @@ val get : Rock.Request.t -> key:string -> string option
 (** Set the value of a cookie with a certain key in a response *)
 val set
   : ?expiration:Cohttp.Cookie.expiration
+  -> ?path:string
+  -> ?domain:string
+  -> ?secure:bool
+  -> ?http_only:bool
   -> Rock.Response.t
   -> key:string
   -> data:string
@@ -17,6 +21,10 @@ val set
 (** Like set but will do multiple cookies at once *)
 val set_cookies
   : ?expiration:Cohttp.Cookie.expiration
+  -> ?path:string
+  -> ?domain:string
+  -> ?secure:bool
+  -> ?http_only:bool
   -> Rock.Response.t
   -> (string * string) list
   -> Rock.Response.t


### PR DESCRIPTION
- Expose all the HTTP cookie directives, not just expiration
- Remove the defaults from `set_cookies` and use `Set_cookie_hdr.make`'s defaults. This is the same for the expiration (both are `Session`), but path is no longer fixed/defaulted to `/`.
- Use `Set_cookie_hdr.t` as the internal representation of the cookie used by the middleware as it has all the fields we want and a sexp representation.

NB: encoding of the cookie data is now done when adding to the Env rather than at the point of serialisation - this might actually make debugging a bit easier as it will be clearer that opium is encoding itself rather than something lower level? But happy to change this back if that seems sensible.