### PR TITLE
String split fix for ocaml < 4.04

### DIFF
--- a/opium.opam
+++ b/opium.opam
@@ -25,6 +25,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.9.0"}
   "re" {>= "1.3.0"}
   "magic-mime"
+  "stringext"
   "alcotest" {test}
   "cow" {test & >= "0.10.0"}
 ]

--- a/opium/jbuild
+++ b/opium/jbuild
@@ -11,4 +11,5 @@
     cmdliner
     cohttp-lwt-unix
     magic-mime
-    logs))))
+    logs
+    stringext))))

--- a/opium/static_serve.ml
+++ b/opium/static_serve.ml
@@ -35,7 +35,7 @@ let public_serve t ~requested ~request_if_none_match ?etag_of_fname ?headers () 
       match request_if_none_match, etag_quoted with
       | Some request_etags, Some etag_quoted ->
         request_etags
-        |> String.split_on_char ','
+        |> Stringext.split ~on:','
         |> List.exists ~f:(fun request_etag ->
           String.trim request_etag = etag_quoted
         )


### PR DESCRIPTION
I noticed the travis build was failing on ocaml 4.03 due to `String.split_on_char` (introduced in `4.04`) . As `stringext` is already a transitive dependency I've added it explicitly and used that to keep compatibility with 4.03.