### PR TITLE
Add README.md for examples

### DIFF
--- a/README.cpp.md
+++ b/README.cpp.md
@@ -51,9 +51,11 @@ and the simple examples below.
 
 ## Examples
 
-All examples are built once the necessary dependencies are installed.
-`$ dune build @examples` will compile all examples. The binaries are located in
-`_build/default/examples/`
+Assuming the necessary dependencies are installed, `$ dune build @examples` will
+compile all examples. The binaries are located in `_build/default/examples/`.
+
+You can execute these binaries directly, though in the examples below we use
+`dune exec` to run them.
 
 ### Hello World
 
@@ -65,17 +67,23 @@ Here's a simple hello world example to get your feet wet:
 #include "examples/hello_world.ml"
 ```
 
-compile with:
+compile and run with:
+
+```sh
+$ dune exec examples/hello_world.exe &
 ```
-$ ocamlbuild -pkg opium.unix hello_world.native
+
+then call
+
+```sh
+curl http://localhost:3000/person/john_doe/42
 ```
 
-and then call
+You should see the JSON message
 
-    ./hello_world.native &
-    curl http://localhost:3000/person/john_doe/42
-
-You should see a JSON message.
+```json
+{"name":"john_doe","age":42}
+```
 
 ### Middleware
 
@@ -98,15 +106,15 @@ favourite browser.
 
 Compile with:
 
-```
-$ ocamlbuild -pkg opium.unix middleware_ua.native
+```sh
+$ dune build examples/middleware_ua.ml
 ```
 
 Here we also use the ability of Opium to generate a cmdliner term to run your
-app. Run your executable with the `-h` to see the options that are available to
-you. For example:
+app. Run your executable with `-h` to see the options that are available to you.
+For example:
 
 ```
 # run in debug mode on port 9000
-$ ./middleware_ua.native -p 9000 -d
+$ dune exec examples/middleware_ua.exe -- -p 9000 -d
 ```

--- a/README.cpp.md
+++ b/README.cpp.md
@@ -37,9 +37,14 @@ $ opam pin add opium --dev-repo
 
 ## Documentation
 
+For the API documentation:
+
 - Read [the hosted documentation for the latest version][hosted-docs].
 - Build and view the docs for version installed locally using [`odig`][odig]:
   `odig doc opium`.
+
+For examples of idiomatic usage, see the [./examples directory](./examples)
+and the simple examples below.
 
 [hosted-docs]: https://rgrinberg.github.io/opium/
 [odig]: https://github.com/b0-system/odig

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ and the simple examples below.
 
 ## Examples
 
-All examples are built once the necessary dependencies are installed.
-`$ dune build @examples` will compile all examples. The binaries are located in
-`_build/default/examples/`
+Assuming the necessary dependencies are installed, `$ dune build @examples` will
+compile all examples. The binaries are located in `_build/default/examples/`.
+
+You can execute these binaries directly, though in the examples below we use
+`dune exec` to run them.
 
 ### Hello World
 
@@ -84,17 +86,23 @@ let print_person =
 let _ = App.empty |> print_param |> print_person |> App.run_command
 ```
 
-compile with:
+compile and run with:
+
+```sh
+$ dune exec examples/hello_world.exe &
 ```
-$ ocamlbuild -pkg opium.unix hello_world.native
+
+then call
+
+```sh
+curl http://localhost:3000/person/john_doe/42
 ```
 
-and then call
+You should see the JSON message
 
-    ./hello_world.native &
-    curl http://localhost:3000/person/john_doe/42
-
-You should see a JSON message.
+```json
+{"name":"john_doe","age":42}
+```
 
 ### Middleware
 
@@ -137,15 +145,15 @@ let _ =
 
 Compile with:
 
-```
-$ ocamlbuild -pkg opium.unix middleware_ua.native
+```sh
+$ dune build examples/middleware_ua.ml
 ```
 
 Here we also use the ability of Opium to generate a cmdliner term to run your
-app. Run your executable with the `-h` to see the options that are available to
-you. For example:
+app. Run your executable with `-h` to see the options that are available to you.
+For example:
 
 ```
 # run in debug mode on port 9000
-$ ./middleware_ua.native -p 9000 -d
+$ dune exec examples/middleware_ua.exe -- -p 9000 -d
 ```

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ $ opam pin add opium --dev-repo
 
 ## Documentation
 
+For the API documentation:
+
 - Read [the hosted documentation for the latest version][hosted-docs].
 - Build and view the docs for version installed locally using [`odig`][odig]:
   `odig doc opium`.
+
+For examples of idiomatic usage, see the [./examples directory](./examples)
+and the simple examples below.
 
 [hosted-docs]: https://rgrinberg.github.io/opium/
 [odig]: https://github.com/b0-system/odig

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,37 @@
+Examples
+========
+
+Assuming the necessary dependencies are installed, `$ dune build @examples` will
+compile all the examples in this directory. The binaries will be located in
+`_build/default/examples/`.
+
+To build and run an example, execute
+
+``` sh
+dune exec examples/<example_name>.exe
+```
+
+This directory includes the following examples:
+
+- [auth_middleware.ml](auth_middleware.ml): Example of adding middleware to
+  implement a simple simple auth system.
+- [exit_hook_example.ml](exit_hook_example.ml): Example showing how to clean up
+  and cleanly exit on program termination.
+- [hello_world_basic.ml](hello_world_basic.ml): An echo server that parses path
+  params and emits JSON.
+- [hello_world_html.ml](hello_world_html.ml): (TODO) Example of serving HTML.
+- [hello_world_log.ml](hello_world_log.ml): Demonstrates configuration of a log
+  reporter and middleware to log HTTP responses.
+- [hello_world.ml](hello_world.ml): The most basic "Hello, World" echo server.
+- [middleware_ua.ml](middleware_ua.ml): Middlware that checks the browser and
+  rejects requests from Microsoft Internet Explorer.
+- [read_json_body.ml](read_json_body.ml): Example of parsing the JSON body of a
+  request.
+- [sample.ml](sample.ml): A larger example including fetching and setting
+  cookies, splatting routes, and serving static resources.
+- [static_serve_override.ml](static_serve_override.ml): Example of serving a
+  static directory, and the fact that routes do not currently override static
+  resources.
+- [uppercase_middleware.ml](uppercase_middleware.ml): A simple middleware that
+  uppercases responses.
+

--- a/examples/hello_world_html.ml
+++ b/examples/hello_world_html.ml
@@ -1,5 +1,6 @@
 open Opium.Std
 
+(* TODO Implement *)
 (* let html_msg msg = <:html< *)
 (* <html> *)
 (* <head> *)


### PR DESCRIPTION
Followup to https://github.com/rgrinberg/opium/issues/124#issuecomment-569076800 

This directs readers to the `examples` directory from within the documentation section of the main readme and adds a readme to the examples directory.

It also updates the instructions around building and running the examples to use dune.