### PR TITLE
Add documentation for urlencoded_pairs_of_body

### DIFF
--- a/opium/app.mli
+++ b/opium/app.mli
@@ -78,6 +78,10 @@ val json_of_body_exn : Request.t -> Ezjsonm.t Lwt.t
 val string_of_body_exn : Request.t -> string Lwt.t
 
 val urlencoded_pairs_of_body : Request.t -> (string * string list) list Lwt.t
+(** Parse a request body encoded according to the
+    [application/x-www-form-urlencoded] content type (typically from POST
+    requests with form data) into an association list of key-value pairs. An
+    exception is raised on invalid data. *)
 
 val param : Request.t -> string -> string
 


### PR DESCRIPTION
Small documentation add. The main intent is to point users in the right place when they search for "form data".