### PR TITLE
Expose a push function for streams

### DIFF
--- a/opium/app.mli
+++ b/opium/app.mli
@@ -108,6 +108,14 @@ val respond' :
   -> body
   -> Response.t Lwt.t
 
+val create_stream :
+     unit
+  -> (   ?headers:Cohttp.Header.t
+      -> ?code:Cohttp.Code.status_code
+      -> unit Lwt.t
+      -> Response.t Lwt.t)
+     * (string -> unit)
+
 val redirect : ?headers:Cohttp.Header.t -> Uri.t -> Response.t
 
 (* Same as return (redirect ...) *)


### PR DESCRIPTION
Second attempt at supporting streams. Instead of exposing
the underlying type, expose an api which gives the user
a push function where they can push strings.