### PR TITLE
Router scope

### DIFF
--- a/opium_kernel/src/middlewares/router.ml
+++ b/opium_kernel/src/middlewares/router.ml
@@ -112,6 +112,15 @@ let splat req =
   Hmap0.find_exn Env.key req.Rock.Request.env |> fun route -> route.Route.splat
 ;;
 
+let scope ~route ~middlewares router routes =
+  ListLabels.iter routes ~f:(fun (meth, subroute, action) ->
+      let action =
+        ListLabels.fold_left middlewares ~init:action ~f:(fun h m ->
+            Rock.Middleware.apply m h)
+      in
+      add router ~action ~meth ~route:(Route.of_string (Filename.concat route subroute)))
+;;
+
 let m endpoints =
   let filter default req =
     match matching_endpoint endpoints req.Rock.Request.meth req.Rock.Request.target with

--- a/opium_kernel/src/opium_kernel.mli
+++ b/opium_kernel/src/opium_kernel.mli
@@ -173,6 +173,35 @@ module Router : sig
   val add : 'a t -> route:Route.t -> meth:Httpaf.Method.t -> action:'a -> 'a t
   val param : Rock.Request.t -> string -> string
   val splat : Rock.Request.t -> string list
+
+  (** [scope] adds scoped routes to the router.
+
+      The scoped routes will be prefixed by [route] and their handlers will be wrapped by
+      [middlewares].
+
+      {4 Example}
+
+      Here's an example that defines a scope that will prefix every routes with "/users"
+      and will wrap the handlers with a middleware defined in [Middleware.require_auth].
+
+      {[
+        let () =
+          Router.scope
+            ~middlewares:[ Middleware.require_auth ]
+            ~route:"/users"
+            router
+            [ `POST, "/register", Handlers.register_user
+            ; `POST, "/login", Handlers.login_user
+            ]
+        ;;
+      ]} *)
+  val scope
+    :  route:string
+    -> middlewares:Rock.Middleware.t list
+    -> Rock.Handler.t t
+    -> (Httpaf.Method.standard * string * Rock.Handler.t) list
+    -> unit
+
   val m : Rock.Handler.t t -> Rock.Middleware.t
 end
 


### PR DESCRIPTION
This PR adds a `Router.scope` function to easily build routers where different middlewares are applied to the routes.

This allows to add routes to the router with the following syntax:
```
let () =
  Router.scope
    ~middlewares:[ Middleware.require_auth ]
    ~route:"/users"
    router
    [ `POST, "/register", Handlers.register_user
    ; `POST, "/login", Handlers.login_user
    ]
```