### PR TITLE
Add a Halt exception to allow early responses

### DIFF
--- a/opium_kernel/src/debugger.ml
+++ b/opium_kernel/src/debugger.ml
@@ -95,7 +95,7 @@ let m () =
       (fun exn ->
         Logs.err ~src:log_src (fun f -> f "%s" (Nifty.Exn.to_string exn));
         let body = format_error req exn |> Body.of_string in
-        Lwt.return @@ Response.make ~status:`Internal_server_error ~body ())
+        halt (Response.make ~status:`Internal_server_error ~body ()))
   in
   Middleware.create ~name:"Debugger" ~filter
 ;;

--- a/opium_kernel/src/opium_kernel.mli
+++ b/opium_kernel/src/opium_kernel.mli
@@ -174,6 +174,20 @@ module Rock : sig
     val append_middleware : t -> Middleware.t -> t
     val create : ?middlewares:Middleware.t list -> handler:Handler.t -> unit -> t
   end
+
+  (** The Halt exception can be raised to stop the interrupt the normal processing flow of
+      a request.
+
+      The exception will be handled by the main run function (in {!Server_connection.run})
+      and the response will be sent to the client directly.
+
+      This is especially useful when you want to make sure that no other middleware will
+      be able to modify the response. *)
+  exception Halt of Response.t
+
+  (** Raises a Halt exception to interrupt the processing of the connection and trigger an
+      early response. *)
+  val halt : Response.t -> unit
 end
 
 module Route : sig

--- a/opium_kernel/src/rock.ml
+++ b/opium_kernel/src/rock.ml
@@ -216,3 +216,7 @@ module App = struct
   let append_middleware t m = { t with middlewares = t.middlewares @ [ m ] }
   let create ?(middlewares = []) ~handler () = { middlewares; handler }
 end
+
+exception Halt of Response.t
+
+let halt response = raise (Halt response)


### PR DESCRIPTION
As discussed, I extracted the early response part of #149 into a single PR.

The reason for adding this is that some middleware might want to take control of the request flow and decide to return the response early. This is the case for instance for an error handler, where once the error is caught and the response is generated, we most likely do not want other middleware to mess with the response.

The implementation is inspired by https://github.com/ocamllabs/ocaml-effects-tutorial.
I've been trying to think of other solutions, but I can't think of one that wouldn't add a lot of overhead. I'm happy to try other implementations if you have any idea 🙂 
