### PR TITLE
Add CORS middleware

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,7 +39,8 @@
   bigstringaf
   re
   uri
-  (alcotest :with-test)))
+  (alcotest :with-test)
+  (alcotest-lwt :with-test)))
 
 (package
  (name opium)
@@ -62,4 +63,5 @@
   sexplib0
   re
   magic-mime
-  (alcotest :with-test)))
+  (alcotest :with-test)
+  (alcotest-lwt :with-test)))

--- a/opium.opam
+++ b/opium.opam
@@ -27,6 +27,7 @@ depends: [
   "re"
   "magic-mime"
   "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/opium_kernel.opam
+++ b/opium_kernel.opam
@@ -24,6 +24,7 @@ depends: [
   "re"
   "uri"
   "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/opium_kernel/src/allow_cors.ml
+++ b/opium_kernel/src/allow_cors.ml
@@ -1,0 +1,110 @@
+(** A middleware that adds Cross-Origin Resource Sharing (CORS) header to the
+    responses. *)
+
+open Rock
+
+let default_origin = [ "*" ]
+let default_credentials = true
+let default_max_age = 1_728_000
+
+let default_headers =
+  [ "Authorization"
+  ; "Content-Type"
+  ; "Accept"
+  ; "Origin"
+  ; "User-Agent"
+  ; "DNT"
+  ; "Cache-Control"
+  ; "X-Mx-ReqToken"
+  ; "Keep-Alive"
+  ; "X-Requested-With"
+  ; "If-Modified-Since"
+  ; "X-CSRF-Token"
+  ]
+;;
+
+let default_expose = []
+let default_methods = [ `GET; `POST; `PUT; `DELETE; `OPTIONS; `Other "PATCH" ]
+let default_send_preflight_response = true
+let request_origin request = Request.get_header request "origin"
+
+let request_vary request =
+  match Request.get_header request "vary" with
+  | None -> []
+  | Some s -> String.split_on_char ',' s
+;;
+
+let allowed_origin origins request =
+  let request_origin = request_origin request in
+  match request_origin with
+  | Some request_origin when List.exists (String.equal request_origin) origins ->
+    Some request_origin
+  | _ -> if List.exists (String.equal "*") origins then Some "*" else None
+;;
+
+let vary_headers allowed_origin hs =
+  let vary_header = request_vary hs in
+  match allowed_origin, vary_header with
+  | Some "*", _ -> []
+  | None, _ -> []
+  | _, [] -> [ "vary", "Origin" ]
+  | _, headers -> [ "vary", "Origin" :: headers |> String.concat "," ]
+;;
+
+let cors_headers ~origins ~credentials ~expose request =
+  let allowed_origin = allowed_origin origins request in
+  let vary_headers = vary_headers allowed_origin request in
+  [ "access-control-allow-origin", allowed_origin |> Option.value ~default:""
+  ; "access-control-expose-headers", String.concat "," expose
+  ; "access-control-allow-credentials", Bool.to_string credentials
+  ]
+  @ vary_headers
+;;
+
+let allowed_headers ~headers request =
+  let value =
+    match headers with
+    | [ "*" ] ->
+      Request.get_header request "access-control-request-headers"
+      |> Option.value ~default:""
+    | headers -> String.concat "," headers
+  in
+  [ "access-control-allow-headers", value ]
+;;
+
+let options_cors_headers ~max_age ~headers ~methods request =
+  let methods = ListLabels.map methods ~f:Method.to_string in
+  [ "access-control-max-age", string_of_int max_age
+  ; "access-control-allow-methods", String.concat "," methods
+  ]
+  @ allowed_headers ~headers request
+;;
+
+let m
+    ?(origins = default_origin)
+    ?(credentials = default_credentials)
+    ?(max_age = default_max_age)
+    ?(headers = default_headers)
+    ?(expose = default_expose)
+    ?(methods = default_methods)
+    ?(send_preflight_response = default_send_preflight_response)
+    ()
+  =
+  let open Lwt.Syntax in
+  let filter handler req =
+    let+ response = handler req in
+    let hs = cors_headers ~origins ~credentials ~expose req in
+    let hs =
+      if req.Request.meth = `OPTIONS
+      then hs @ options_cors_headers ~max_age ~headers ~methods req
+      else hs
+    in
+    match send_preflight_response, req.Request.meth with
+    | true, `OPTIONS -> Response.make ~status:`No_content ~headers:(Headers.of_list hs) ()
+    | _ ->
+      { response with
+        headers = Headers.add_list response.Response.headers (hs |> List.rev)
+      }
+  in
+  Middleware.create ~name:"Allow CORS" ~filter
+;;

--- a/opium_kernel/src/opium_kernel.ml
+++ b/opium_kernel/src/opium_kernel.ml
@@ -12,4 +12,5 @@ module Middleware = struct
   let router = Router.m
   let debugger = Debugger.m
   let logger = Logger.m
+  let allow_cors = Allow_cors.m
 end

--- a/opium_kernel/src/opium_kernel.mli
+++ b/opium_kernel/src/opium_kernel.mli
@@ -221,4 +221,15 @@ module Middleware : sig
     :  ?time_f:((unit -> Rock.Response.t Lwt.t) -> Mtime.span * Rock.Response.t Lwt.t)
     -> unit
     -> Rock.Middleware.t
+
+  val allow_cors
+    :  ?origins:string list
+    -> ?credentials:bool
+    -> ?max_age:int
+    -> ?headers:string list
+    -> ?expose:string list
+    -> ?methods:Httpaf.Method.t list
+    -> ?send_preflight_response:bool
+    -> unit
+    -> Rock.Middleware.t
 end

--- a/opium_kernel/test/dune
+++ b/opium_kernel/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names core_route)
- (libraries alcotest opium_kernel)
+ (names core_route middleware_allow_cors)
+ (libraries alcotest alcotest-lwt lwt opium_kernel)
  (package opium_kernel)
  (action
   (run %{test} -q --color=always)))

--- a/opium_kernel/test/middleware_allow_cors.ml
+++ b/opium_kernel/test/middleware_allow_cors.ml
@@ -1,0 +1,130 @@
+open Opium_kernel
+
+let request = Alcotest.of_pp Rock.Request.pp_hum
+let response = Alcotest.of_pp Rock.Response.pp_hum
+
+let with_service ?middlewares ?handler f =
+  let handler =
+    Option.value handler ~default:(fun _req -> Lwt.return @@ Rock.Response.make ())
+  in
+  let middlewares = Option.value middlewares ~default:[] in
+  let app = Rock.App.create ~middlewares ~handler () in
+  let { Rock.App.middlewares; handler } = app in
+  let filters = ListLabels.map ~f:(fun m -> m.Rock.Middleware.filter) middlewares in
+  let service = Rock.Filter.apply_all filters handler in
+  f service
+;;
+
+let check_response ?headers ?status res =
+  let expected =
+    Rock.Response.make ?status ?headers:(Option.map Rock.Headers.of_list headers) ()
+  in
+  Alcotest.(check response) "same response" expected res
+;;
+
+let test_regular_request () =
+  let open Lwt.Syntax in
+  let+ res =
+    with_service ~middlewares:[ Middleware.allow_cors () ] (fun service ->
+        let req = Rock.Request.make "/" `GET () in
+        service req)
+  in
+  check_response
+    ~headers:
+      [ "access-control-allow-origin", "*"
+      ; "access-control-expose-headers", ""
+      ; "access-control-allow-credentials", "true"
+      ]
+    res
+;;
+
+let test_overwrite_origin () =
+  let open Lwt.Syntax in
+  let+ res =
+    with_service
+      ~middlewares:[ Middleware.allow_cors ~origins:[ "http://example.com" ] () ]
+      (fun service ->
+        let req =
+          Rock.Request.make
+            "/"
+            `GET
+            ~headers:(Rock.Headers.of_list [ "origin", "http://example.com" ])
+            ()
+        in
+        service req)
+  in
+  check_response
+    ~headers:
+      [ "access-control-allow-origin", "http://example.com"
+      ; "access-control-expose-headers", ""
+      ; "access-control-allow-credentials", "true"
+      ; "vary", "Origin"
+      ]
+    res
+;;
+
+let test_return_204_for_options () =
+  let open Lwt.Syntax in
+  let+ res =
+    with_service ~middlewares:[ Middleware.allow_cors () ] (fun service ->
+        let req = Rock.Request.make "/" `OPTIONS () in
+        service req)
+  in
+  check_response
+    ~status:`No_content
+    ~headers:
+      [ "access-control-allow-origin", "*"
+      ; "access-control-expose-headers", ""
+      ; "access-control-allow-credentials", "true"
+      ; "access-control-max-age", "1728000"
+      ; "access-control-allow-methods", "GET,POST,PUT,DELETE,OPTIONS,PATCH"
+      ; ( "access-control-allow-headers"
+        , "Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since,X-CSRF-Token"
+        )
+      ]
+    res
+;;
+
+let test_allow_request_headers () =
+  let open Lwt.Syntax in
+  let+ res =
+    with_service
+      ~middlewares:[ Middleware.allow_cors ~headers:[ "*" ] () ]
+      (fun service ->
+        let req =
+          Rock.Request.make
+            "/"
+            `OPTIONS
+            ~headers:
+              (Rock.Headers.of_list [ "access-control-request-headers", "header-1,header-2" ])
+            ()
+        in
+        service req)
+  in
+  check_response
+    ~status:`No_content
+    ~headers:
+      [ "access-control-allow-origin", "*"
+      ; "access-control-expose-headers", ""
+      ; "access-control-allow-credentials", "true"
+      ; "access-control-max-age", "1728000"
+      ; "access-control-allow-methods", "GET,POST,PUT,DELETE,OPTIONS,PATCH"
+      ; "access-control-allow-headers", "header-1,header-2"
+      ]
+    res
+;;
+
+let () =
+  Lwt_main.run
+  @@ Alcotest_lwt.run
+       "Middleware :: Allow CORS"
+       [ ( "headers"
+         , [ "Regular request returns correct headers", `Quick, test_regular_request
+           ; "Overwrites origin header", `Quick, test_overwrite_origin
+           ; "Allow incoming request headers", `Quick, test_allow_request_headers
+           ; ( "Returns No Content for OPTIONS requests"
+             , `Quick
+             , test_return_204_for_options )
+           ] )
+       ]
+;;


### PR DESCRIPTION
This PR adds a middleware to manage CORS headers.

It adds the appropriate headers for regular requests and handles [preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/preflight_request).

It depends on #162, but I can refactor if you prefer not to merge it.