### PR TITLE
Allow using a custom host to bind the server.

### DIFF
--- a/opium/app.mli
+++ b/opium/app.mli
@@ -16,6 +16,7 @@ val empty : t
     Builders are usuallys composed with a base app using (|>) to create a full app *)
 type builder = t -> t
 
+val host : string -> builder
 val port : int -> builder
 val ssl : cert:string -> key:string -> builder
 val cmd_name : string -> builder


### PR DESCRIPTION
Currently the server binds to `inet_addr_loopback` (_i.e._ localhost). This PR adds support for setting a custom host when starting the app.

The host can be set similarly to the port with a builder option:

```ocaml
  App.empty
  |> App.host "localhost"
  |> App.port port
  ...
  |> App.start
```

By default the host is set to `0.0.0.0`.