### PR TITLE
Make Rock.Body types public

### DIFF
--- a/opium_kernel/src/opium_kernel.mli
+++ b/opium_kernel/src/opium_kernel.mli
@@ -21,7 +21,6 @@ module Rock : sig
 
   module Body : sig
     type content =
-      private
       [ `Empty
       | `String of string
       | `Bigstring of Bigstringaf.t
@@ -29,7 +28,7 @@ module Rock : sig
       ]
 
     (** [t] represents an HTTP message body. *)
-    type t = private
+    type t =
       { length : Int64.t option
       ; content : content
       }


### PR DESCRIPTION
Having the Body types private prevents users from implementing middlewares that make use of the body of the request. For instance, it is currently difficult to implement a custom logger.

@anuragsoni Is there any reason for making these types private? I don't want to undo a change that you made for a specific reason.

Related to https://github.com/rgrinberg/opium/issues/176