### PR TITLE
Add magic mime opium kernel

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: avsm/setup-ocaml@v1
         with:
-          ocaml-version: 4.10.0
+          ocaml-version: 4.11.1
       - name: Install dependencies
         run: opam install dune ocamlformat
       - name: Format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ['4.10.0', '4.09.1', '4.08.1' ]
+        ocaml-version: ['4.11.1', '4.10.1', '4.09.1', '4.08.1' ]
     steps:
       - uses: actions/checkout@v2
       - uses: avsm/setup-ocaml@v1

--- a/dune-project
+++ b/dune-project
@@ -34,6 +34,7 @@
   fieldslib
   sexplib0
   logs
+  magic-mime
   mtime
   yojson
   bigstringaf
@@ -62,6 +63,5 @@
   cmdliner
   sexplib0
   re
-  magic-mime
   (alcotest :with-test)
   (alcotest-lwt :with-test)))

--- a/opium.opam
+++ b/opium.opam
@@ -25,7 +25,6 @@ depends: [
   "cmdliner"
   "sexplib0"
   "re"
-  "magic-mime"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
 ]

--- a/opium_kernel.opam
+++ b/opium_kernel.opam
@@ -18,6 +18,7 @@ depends: [
   "fieldslib"
   "sexplib0"
   "logs"
+  "magic-mime"
   "mtime"
   "yojson"
   "bigstringaf"


### PR DESCRIPTION
#152 moved `magic-mime` dependency to `opium_kernel`, but the opam files didn't reflect this. This resulted in a compilation error when pinning `opium_kernel` because of the missing dependency.