### PR TITLE
Fix broken CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         id: cache-opam
         with:
           path: ~/.opam
-          key: v2-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('opium.opam.locked') }}-${{ hashFiles('opium_kernel.opam.locked') }}
+          key: v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('*.opam.locked') }}
           restore-keys: |
             v2-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-
 
@@ -45,9 +45,9 @@ jobs:
           opam install . --deps-only --with-doc --with-test --locked --unlock-base
           opam install ppx_sexp_conv base64 ppx_yojson_conv --skip-updates
 
-      - name: Upgrade dependencies
-        run: opam upgrade --fixup
+      - name: Recover from an Opam broken state
         if: steps.cache-opam.outputs.cache-hit == 'true'
+        run: opam upgrade --fixup
 
       - name: Build
         run: make build

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,9 +27,9 @@ jobs:
         id: cache-opam
         with:
           path: ~/.opam
-          key: v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-
+          key: v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}
           restore-keys: |
-            v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}-
+            v1-${{ runner.os }}-opam-${{ matrix.ocaml-version }}
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1
@@ -40,9 +40,9 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: opam install ocamlformat
 
-      - name: Upgrade dependencies
-        run: opam upgrade --fixup
+      - name: Recover from an Opam broken state
         if: steps.cache-opam.outputs.cache-hit == 'true'
+        run: opam upgrade --fixup
 
       - name: Format
         run: opam exec -- dune build @fmt --auto-promote || true


### PR DESCRIPTION
The way ocaml-setup is implemented prevents us from using caching on different versions of OCaml so merging #183 broke the CI on master.

I'm experimenting with changes to `setup-ocaml` to fix the issue, otherwise, I'll comment out the caching parts of the workflow.