### PR TITLE
Rename Hmap to Hmap0 in public interface

### DIFF
--- a/opium/opium.ml
+++ b/opium/opium.ml
@@ -26,4 +26,4 @@ module Std = struct
   include App_export
 end
 
-module Hmap = Opium_kernel.Hmap0
+module Hmap = Opium_kernel.Hmap

--- a/opium_kernel/src/opium_kernel.ml
+++ b/opium_kernel/src/opium_kernel.ml
@@ -1,4 +1,4 @@
-module Hmap0 = Hmap0
+module Hmap = Hmap0
 module Headers = Headers
 module Body = Body
 module Method = Method

--- a/opium_kernel/src/opium_kernel.mli
+++ b/opium_kernel/src/opium_kernel.mli
@@ -2,7 +2,7 @@
 
     [Opium_kernel] is a Sinatra like web toolkit for OCaml, based on Httpaf and Lwt. *)
 
-module Hmap0 = Hmap0
+module Hmap = Hmap0
 module Request = Request
 module Response = Response
 module Headers = Headers


### PR DESCRIPTION
It should only be referred to as Hmap0 when we need to differentiate it
with the toplevel Hmap module.