### PR TITLE
Add cookie or replace

### DIFF
--- a/opium_kernel/src/middlewares/middleware_logger.ml
+++ b/opium_kernel/src/middlewares/middleware_logger.ml
@@ -11,7 +11,7 @@ let body_to_string ?(content_type = "text/plain") ?(max_len = 1000) body =
   in
   match lhs, rhs with
   | "text", _ | "application", "json" | "application", "x-www-form-urlencoded" ->
-    let+ s = Body.to_string body in
+    let+ s = Body.copy body |> Body.to_string in
     if String.length s > max_len
     then
       String.sub s 0 (min (String.length s) max_len)

--- a/opium_kernel/src/response.ml
+++ b/opium_kernel/src/response.ml
@@ -99,6 +99,15 @@ let add_cookie ?sign_with ?expires ?scope ?same_site ?secure ?http_only value t 
     Cookie.make ?sign_with ?expires ?scope ?same_site ?secure ?http_only value
     |> Cookie.to_set_cookie_header
   in
+  add_header cookie_header t
+;;
+
+let add_cookie_or_replace ?sign_with ?expires ?scope ?same_site ?secure ?http_only value t
+  =
+  let cookie_header =
+    Cookie.make ?sign_with ?expires ?scope ?same_site ?secure ?http_only value
+    |> Cookie.to_set_cookie_header
+  in
   let headers =
     replace_or_add_to_list
       ~f:(fun (k, v) _ ->

--- a/opium_kernel/src/response.mli
+++ b/opium_kernel/src/response.mli
@@ -516,6 +516,26 @@ val add_cookie
   -> t
   -> t
 
+(** {3 [add_cookie_or_replace]} *)
+
+(** [add_cookie_or_replace ?sign_with ?expires ?scope ?same_site ?secure ?http_only value
+    t] adds a cookie with value [value] to the response [t].
+
+    If a cookie with the same key already exists, its value will be replaced with the new
+    value of [value].
+
+    If [sign_with] is provided, the cookie will be signed with the given Signer. *)
+val add_cookie_or_replace
+  :  ?sign_with:Cookie.Signer.t
+  -> ?expires:Cookie.expires
+  -> ?scope:Uri.t
+  -> ?same_site:Cookie.same_site
+  -> ?secure:bool
+  -> ?http_only:bool
+  -> Cookie.value
+  -> t
+  -> t
+
 (** {3 [add_cookie_unless_exists]} *)
 
 (** [add_cookie_unless_exists ?sign_with ?expires ?scope ?same_site ?secure ?http_only


### PR DESCRIPTION
Adds a function `add_cookie_or_replace` to the Response module. The `add_cookie` function now adds a cookie, regardless of whether the cookie is already present.

Also, fixes a bug in the logger module that was draining stream bodies.