### PR TITLE
[Fix] Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ let streaming_handler req =
 
 let print_param_handler req =
   Printf.sprintf "Hello, %s\n" (Router.param req "name")
-  |> Response.of_plain_text
+  |> Response.of_string_body
   |> Lwt.return
 ;;
 


### PR DESCRIPTION
Dear, Reviewers.

I found some issue on example code on README.md. Since `Response.of_plain_text` method not available 0.18.0 , So i update it with method `Response.of_string_body` which had equivalent result.

Thank you.