### PR TITLE
remove references to ssl

### DIFF
--- a/opium/src/app.mli
+++ b/opium/src/app.mli
@@ -25,7 +25,6 @@ val host : string -> builder
 val backlog : int -> builder
 
 val port : int -> builder
-val ssl : cert:string -> key:string -> builder
 val cmd_name : string -> builder
 
 (** [not_found] accepts a regular Opium handler that will be used instead of the default


### PR DESCRIPTION
httpaf based opium doesn't work with lwt_ssl/ocaml-tls at the moment.
Removing cli params that talk about ssl should prevent any confusion about this. (see: #230)