### PR TITLE
Add odoc with-doc dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,8 @@
   hmap
   httpaf
   lwt
-  sexplib0))
+  sexplib0
+  (odoc :with-doc)))
 
 (package
  (name opium)
@@ -59,6 +60,7 @@
   re
   uri
   multipart-form-data
+  (odoc :with-doc)
   (alcotest :with-test)
   (alcotest-lwt :with-test)))
 
@@ -73,4 +75,5 @@
   (opium
    (= :version))
   alcotest
-  alcotest-lwt))
+  alcotest-lwt
+  (odoc :with-doc)))

--- a/opium-testing.opam
+++ b/opium-testing.opam
@@ -15,6 +15,7 @@ depends: [
   "opium" {= version}
   "alcotest"
   "alcotest-lwt"
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/opium-testing.opam.locked
+++ b/opium-testing.opam.locked
@@ -36,6 +36,7 @@ depends: [
   "faraday-lwt" {= "0.7.2"}
   "faraday-lwt-unix" {= "0.7.2"}
   "fmt" {= "0.8.9"}
+  "fpath" {= "0.7.3" & with-doc}
   "hmap" {= "0.8.1"}
   "httpaf" {= "0.6.6"}
   "httpaf-lwt-unix" {= "0.6.6"}
@@ -54,6 +55,7 @@ depends: [
   "ocamlbuild" {= "0.14.0"}
   "ocamlfind" {= "1.8.1"}
   "ocplib-endian" {= "1.1"}
+  "odoc" {= "1.5.2" & with-doc}
   "opium" {= "0.18.0"}
   "ppx_derivers" {= "1.2.1"}
   "ppx_tools_versioned" {= "5.4.0"}

--- a/opium.opam
+++ b/opium.opam
@@ -31,6 +31,7 @@ depends: [
   "multipart-form-data"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/opium.opam
+++ b/opium.opam
@@ -29,9 +29,9 @@ depends: [
   "re"
   "uri"
   "multipart-form-data"
+  "odoc" {with-doc}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/opium.opam.locked
+++ b/opium.opam.locked
@@ -36,6 +36,7 @@ depends: [
   "faraday-lwt" {= "0.7.2"}
   "faraday-lwt-unix" {= "0.7.2"}
   "fmt" {= "0.8.9"}
+  "fpath" {= "0.7.3" & with-doc}
   "hmap" {= "0.8.1"}
   "httpaf" {= "0.6.6"}
   "httpaf-lwt-unix" {= "0.6.6"}
@@ -54,6 +55,7 @@ depends: [
   "ocamlbuild" {= "0.14.0"}
   "ocamlfind" {= "1.8.1"}
   "ocplib-endian" {= "1.1"}
+  "odoc" {= "1.5.2" & with-doc}
   "ppx_derivers" {= "1.2.1"}
   "ppx_tools_versioned" {= "5.4.0"}
   "ptime" {= "0.8.5"}

--- a/rock.opam
+++ b/rock.opam
@@ -18,6 +18,7 @@ depends: [
   "httpaf"
   "lwt"
   "sexplib0"
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/rock.opam.locked
+++ b/rock.opam.locked
@@ -12,11 +12,13 @@ doc: "https://rgrinberg.github.io/opium/"
 bug-reports: "https://github.com/rgrinberg/opium/issues"
 depends: [
   "angstrom" {= "0.15.0"}
+  "astring" {= "0.8.5" & with-doc}
   "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "bigarray-compat" {= "1.0.0"}
   "bigstringaf" {= "0.7.0"}
+  "cmdliner" {= "1.0.4" & with-doc}
   "conf-m4" {= "1"}
   "conf-pkg-config" {= "1.3"}
   "cppo" {= "1.6.6"}
@@ -24,6 +26,7 @@ depends: [
   "dune" {= "2.7.1"}
   "dune-configurator" {= "2.7.1"}
   "faraday" {= "0.7.2"}
+  "fpath" {= "0.7.3" & with-doc}
   "hmap" {= "0.8.1"}
   "httpaf" {= "0.6.6"}
   "lwt" {= "5.3.0"}
@@ -34,10 +37,15 @@ depends: [
   "ocamlbuild" {= "0.14.0"}
   "ocamlfind" {= "1.8.1"}
   "ocplib-endian" {= "1.1"}
+  "odoc" {= "1.5.2" & with-doc}
+  "re" {= "1.9.0" & with-doc}
   "result" {= "1.5"}
   "seq" {= "base"}
   "sexplib0" {= "v0.14.0"}
   "topkg" {= "1.0.3"}
+  "tyxml" {= "4.4.0" & with-doc}
+  "uchar" {= "0.0.2" & with-doc}
+  "uutf" {= "1.0.2" & with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
Should enable us to `opam install --with-doc opium`.