### PR TITLE
static_serve: comment does not reflect the code

### DIFF
--- a/example/static_serve/main.ml
+++ b/example/static_serve/main.ml
@@ -1,11 +1,3 @@
-(* example showcasing a bug (or conflict) caused by the router interacting with static
-   middleware. Run this example and try:
-
-   $ curl localhost:3000/examples/hello_world.ml
-
-   The result will be the corresponding file in ./examples/ rather than the string
-   "hello_world". *)
-
 open Opium
 
 let () =


### PR DESCRIPTION
This PR removes the comment in `example/static_serve/main.ml` which does not reflect what the program actually does.

I think the mentioned example is worth having, though.