### PR TITLE
Basic auth middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           opam install . --deps-only --with-doc --with-test --locked --unlock-base
-          opam install ocamlformat ppx_sexp_conv ppx_yojson_conv --skip-updates
+          opam install ocamlformat --skip-updates
 
       - name: Recover from an Opam broken state
         if: steps.cache-opam.outputs.cache-hit == 'true'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "ocaml.sandbox": {
+        "kind": "opam",
+        "switch": "${workspaceFolder:opium}"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "ocaml.sandbox": {
-        "kind": "opam",
-        "switch": "${workspaceFolder:opium}"
-    }
-}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,14 @@ module Person = struct
     { name : string
     ; age : int
     }
-  [@@deriving yojson]
+
+  let yojson_of_t t = `Assoc [ "name", `String t.name; "age", `Int t.age ]
+
+  let t_of_yojson yojson =
+    match yojson with
+    | `Assoc [ ("name", `String name); ("age", `Int age) ] -> { name; age }
+    | _ -> failwith "invalid person json"
+  ;;
 end
 
 let print_person_handler req =

--- a/example/hello_world/dune
+++ b/example/hello_world/dune
@@ -1,5 +1,3 @@
 (executable
  (name main)
- (preprocess
-  (pps ppx_yojson_conv))
  (libraries opium))

--- a/example/hello_world/main.ml
+++ b/example/hello_world/main.ml
@@ -5,7 +5,14 @@ module Person = struct
     { name : string
     ; age : int
     }
-  [@@deriving yojson]
+
+  let yojson_of_t t = `Assoc [ "name", `String t.name; "age", `Int t.age ]
+
+  let t_of_yojson yojson =
+    match yojson with
+    | `Assoc [ ("name", `String name); ("age", `Int age) ] -> { name; age }
+    | _ -> failwith "invalid person json"
+  ;;
 end
 
 let print_person_handler req =

--- a/example/user_auth/README.md
+++ b/example/user_auth/README.md
@@ -9,16 +9,13 @@ This example implements a very simple authentication system using `Basic` authen
 The middleware stores the authenticated user in the request's context, which can be retrieved in the handlers.
 
 The username and password for the authentication are `admin` and `admin`.
-The corresponding `Basic` header is `Basic YWRtaW46YWRtaW4=`.
 
-You can test that you are unauthorized to access the `/` endpoint without the correct authorization header:
-
-```sh
-curl http://localhost:3000/ -X GET
-```
-
-And that you are allows to access when you provide it:
-
+You can test that you are authorized to access the `/` endpoint with the correct `Authorization` header:
 ```sh
 curl http://localhost:3000/ -X GET --user admin:admin
+```
+
+And that you are not allows to access it when you don't provide the a valid `Authorization` header:
+```sh
+curl http://localhost:3000/ -X GET
 ```

--- a/example/user_auth/README.md
+++ b/example/user_auth/README.md
@@ -20,5 +20,5 @@ curl http://localhost:3000/ -X GET
 And that you are allows to access when you provide it:
 
 ```sh
-curl http://localhost:3000/ -X GET -H "Authorization: Basic YWRtaW46YWRtaW4="
+curl http://localhost:3000/ -X GET --user admin:admin
 ```

--- a/example/user_auth/README.md
+++ b/example/user_auth/README.md
@@ -7,3 +7,18 @@ dune exec example/user_auth/main.exe
 This example implements a very simple authentication system using `Basic` authentication.
 
 The middleware stores the authenticated user in the request's context, which can be retrieved in the handlers.
+
+The username and password for the authentication are `admin` and `admin`.
+The corresponding `Basic` header is `Basic YWRtaW46YWRtaW4=`.
+
+You can test that you are unauthorized to access the `/` endpoint without the correct authorization header:
+
+```sh
+curl http://localhost:3000/ -X GET
+```
+
+And that you are allows to access when you provide it:
+
+```sh
+curl http://localhost:3000/ -X GET -H "Authorization: Basic YWRtaW46YWRtaW4="
+```

--- a/example/user_auth/dune
+++ b/example/user_auth/dune
@@ -1,5 +1,3 @@
 (executable
  (name main)
- (preprocess
-  (pps ppx_sexp_conv))
  (libraries opium))

--- a/example/user_auth/main.ml
+++ b/example/user_auth/main.ml
@@ -1,96 +1,55 @@
 open Opium
-open Sexplib0.Sexp_conv
 
-module Auth = struct
-  (* https://github.com/mirage/ocaml-cohttp/blob/35e1386dcca759bcc955c59c7e91260f765f253b/cohttp/src/auth.ml *)
-  (*{{{ Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
-   *
-   * Permission to use, copy, modify, and distribute this software for any
-   * purpose with or without fee is hereby granted, provided that the above
-   * copyright notice and this permission notice appear in all copies.
-   *
-   * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-   * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-   * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-   * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-   * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-   * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-   * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-   *
-  }}}*)
+module User = struct
+  type t = { username : string }
 
-  open Sexplib0.Sexp_conv
-  open Printf
-
-  type challenge = [ `Basic of string (* realm *) ] [@@deriving sexp]
-
-  type credential =
-    [ `Basic of string * string (* username, password *)
-    | `Other of string
-    ]
-  [@@deriving sexp]
-
-  let string_of_credential (cred : credential) =
-    match cred with
-    | `Basic (user, pass) -> "Basic " ^ Base64.encode_string (sprintf "%s:%s" user pass)
-    | `Other buf -> buf
+  let t_of_sexp sexp =
+    let open Sexplib0.Sexp in
+    match sexp with
+    | List [ Atom "username"; Atom username ] -> { username }
+    | _ -> failwith "invalid user sexp"
   ;;
 
-  let credential_of_string (buf : string) : credential =
-    try
-      let b64 = Scanf.sscanf buf "Basic %s" (fun b -> b) in
-      match Stringext.split ~on:':' (Base64.decode_exn b64) ~max:2 with
-      | [ user; pass ] -> `Basic (user, pass)
-      | _ -> `Other buf
-    with
-    | _ -> `Other buf
-  ;;
-
-  let string_of_challenge (ty : challenge) =
-    match ty with
-    | `Basic realm -> sprintf "Basic realm=\"%s\"" realm
+  let sexp_of_t t =
+    let open Sexplib0.Sexp in
+    List [ Atom "username"; Atom t.username ]
   ;;
 end
 
-type user = { username : string (* ... *) } [@@deriving sexp]
+module Env_user = struct
+  type user' = User.t
 
-(* My convention is to stick the keys inside an Env sub module. By not exposing this
-   module in the mli we are preventing the user or other middleware from meddling with our
-   values by not using our interface *)
-module Env = struct
-  (* or use type nonrec *)
-  type user' = user
-
-  let key : user' Opium.Context.key = Opium.Context.Key.create ("user", [%sexp_of: user])
+  let key : user' Opium.Context.key = Opium.Context.Key.create ("user", User.sexp_of_t)
 end
 
-(* Usually middleware gets its own module so the middleware constructor function is
-   usually shortened to m. For example, [Auth.m] is obvious enough.
-
-   The auth param (auth : username:string -> password:string -> user option) would
-   represent our database model. E.g. it would do some lookup in the db and fetch the
-   user. *)
-let m auth =
-  let filter handler ({ Request.headers; env; _ } as req) =
-    match
-      Option.map Auth.credential_of_string (Httpaf.Headers.get headers "authorization")
-    with
-    | None ->
-      (* could redirect here, but we return user as an option type *)
-      handler req
-    | Some (`Other _) ->
-      (* handle other, non-basic authentication mechanisms *)
-      handler req
-    | Some (`Basic (username, password)) ->
-      (match auth ~username ~password with
-      | None -> failwith "TODO: bad username/password pair"
-      | Some user ->
-        (* we have a user. let's add him to req *)
-        let env = Opium.Context.add Env.key user env in
-        let req = { req with Request.env } in
-        handler req)
-  in
-  Rock.Middleware.create ~name:"http basic auth" ~filter
+let admin_handler req =
+  let user = Opium.Context.find_exn Env_user.key req.Request.env in
+  Response.of_plain_text (Printf.sprintf "Welcome back, %s!\n" user.username)
+  |> Lwt.return
 ;;
 
-let user { Request.env; _ } = Opium.Context.find Env.key env
+let unauthorized_handler _req =
+  Response.of_plain_text ~status:`Unauthorized "Unauthorized!\n" |> Lwt.return
+;;
+
+let auth_callback ~username ~password =
+  match username, password with
+  | "admin", "admin" -> Some User.{ username }
+  | _ -> None
+;;
+
+let auth_middleware =
+  Middleware.basic_auth
+    ~key:Env_user.key
+    ~auth_callback
+    ~realm:"my_realm"
+    ~unauthorized_handler
+    ()
+;;
+
+let _ =
+  App.empty
+  |> App.middleware auth_middleware
+  |> App.get "/" admin_handler
+  |> App.run_command
+;;

--- a/example/user_auth/main.ml
+++ b/example/user_auth/main.ml
@@ -17,9 +17,9 @@ module User = struct
 end
 
 module Env_user = struct
-  type user' = User.t
+  type t = User.t
 
-  let key : user' Opium.Context.key = Opium.Context.Key.create ("user", User.sexp_of_t)
+  let key : t Opium.Context.key = Opium.Context.Key.create ("user", User.sexp_of_t)
 end
 
 let admin_handler req =
@@ -34,8 +34,8 @@ let unauthorized_handler _req =
 
 let auth_callback ~username ~password =
   match username, password with
-  | "admin", "admin" -> Some User.{ username }
-  | _ -> None
+  | "admin", "admin" -> Lwt.return_some User.{ username }
+  | _ -> Lwt.return_none
 ;;
 
 let auth_middleware =

--- a/opium/src/auth.ml
+++ b/opium/src/auth.ml
@@ -1,0 +1,57 @@
+module Challenge = struct
+  type t = Basic of string
+
+  let t_of_sexp =
+    let open Sexplib0.Sexp in
+    function
+    | List [ Atom "basic"; Atom s ] -> Basic s
+    | _ -> failwith "invalid challenge sexp"
+  ;;
+
+  let sexp_of_t =
+    let open Sexplib0.Sexp in
+    function
+    | Basic s -> List [ Atom "basic"; Atom s ]
+  ;;
+end
+
+module Credential = struct
+  type t =
+    | Basic of string * string (* username, password *)
+    | Other of string
+
+  let t_of_sexp =
+    let open Sexplib0.Sexp in
+    function
+    | List [ Atom "basic"; Atom u; Atom p ] -> Basic (u, p)
+    | _ -> failwith "invalid credential sexp"
+  ;;
+
+  let sexp_of_t =
+    let open Sexplib0.Sexp in
+    function
+    | Basic (u, p) -> List [ Atom "basic"; Atom u; Atom p ]
+    | Other s -> List [ Atom "other"; Atom s ]
+  ;;
+end
+
+let string_of_credential (cred : Credential.t) =
+  match cred with
+  | Basic (user, pass) ->
+    "Basic " ^ Base64.encode_string (Printf.sprintf "%s:%s" user pass)
+  | Other buf -> buf
+;;
+
+let credential_of_string (buf : string) : Credential.t =
+  try
+    let b64 = Scanf.sscanf buf "Basic %s" (fun b -> b) in
+    match Stringext.split ~on:':' (Base64.decode_exn b64) ~max:2 with
+    | [ user; pass ] -> Basic (user, pass)
+    | _ -> Other buf
+  with
+  | _ -> Other buf
+;;
+
+let string_of_challenge = function
+  | Challenge.Basic realm -> Printf.sprintf "Basic realm=\"%s\"" realm
+;;

--- a/opium/src/auth.mli
+++ b/opium/src/auth.mli
@@ -33,12 +33,12 @@ end
 (** {3 [string_of_credential]} *)
 
 (** [string_of_credential cred] converts the credentials into a string usable in the
-    [Authentication] header. *)
+    [Authorization] header. *)
 val string_of_credential : Credential.t -> string
 
 (** {3 [credential_of_string]} *)
 
-(** [credential_of_string s] parses a string from the [Authentication] header into
+(** [credential_of_string s] parses a string from the [Authorization] header into
     credentials. *)
 val credential_of_string : string -> Credential.t
 

--- a/opium/src/auth.mli
+++ b/opium/src/auth.mli
@@ -1,0 +1,19 @@
+module Challenge : sig
+  type t = Basic of string
+
+  val t_of_sexp : Sexplib0.Sexp.t -> t
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+end
+
+module Credential : sig
+  type t =
+    | Basic of string * string
+    | Other of string
+
+  val t_of_sexp : Sexplib0.Sexp.t -> t
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+end
+
+val string_of_credential : Credential.t -> string
+val credential_of_string : string -> Credential.t
+val string_of_challenge : Challenge.t -> string

--- a/opium/src/auth.mli
+++ b/opium/src/auth.mli
@@ -1,19 +1,49 @@
+(** Authentication functions to work with common HTTP authentication methods. *)
+
 module Challenge : sig
   type t = Basic of string
 
+  (** {3 [t_of_sexp]} *)
+
+  (** [t_of_sexp sexp] parses the s-expression [sexp] into a challenge *)
   val t_of_sexp : Sexplib0.Sexp.t -> t
+
+  (** {3 [sexp_of_t]} *)
+
+  (** [sexp_of_t t] converts the challenge [t] to an s-expression *)
   val sexp_of_t : t -> Sexplib0.Sexp.t
 end
 
 module Credential : sig
   type t =
-    | Basic of string * string
+    | Basic of string * string (* username, password *)
     | Other of string
 
+  (** {3 [t_of_sexp]} *)
+
+  (** [t_of_sexp sexp] parses the s-expression [sexp] into credentials *)
   val t_of_sexp : Sexplib0.Sexp.t -> t
+
+  (** {3 [sexp_of_t]} *)
+
+  (** [sexp_of_t t] converts the credentials [t] to an s-expression *)
   val sexp_of_t : t -> Sexplib0.Sexp.t
 end
 
+(** {3 [string_of_credential]} *)
+
+(** [string_of_credential cred] converts the credentials into a string usable in the
+    [Authentication] header. *)
 val string_of_credential : Credential.t -> string
+
+(** {3 [credential_of_string]} *)
+
+(** [credential_of_string s] parses a string from the [Authentication] header into
+    credentials. *)
 val credential_of_string : string -> Credential.t
+
+(** {3 [string_of_challenge]} *)
+
+(** [string_of_challenge challenge] converts the challenge into a string usable in the
+    [WWW-Authenticate] response header. *)
 val string_of_challenge : Challenge.t -> string

--- a/opium/src/middlewares/middleware_basic_auth.ml
+++ b/opium/src/middlewares/middleware_basic_auth.ml
@@ -10,9 +10,10 @@ let m ?unauthorized_handler ~key ~realm ~auth_callback () =
     let+ resp =
       match Request.authorization req with
       | None -> unauthorized_handler req
-      | Some (Other _) -> handler req
+      | Some (Other _) -> unauthorized_handler req
       | Some (Basic (username, password)) ->
-        (match auth_callback ~username ~password with
+        let* user_opt = auth_callback ~username ~password in
+        (match user_opt with
         | None -> unauthorized_handler req
         | Some user ->
           let env = Context.add key user env in

--- a/opium/src/middlewares/middleware_basic_auth.ml
+++ b/opium/src/middlewares/middleware_basic_auth.ml
@@ -1,0 +1,30 @@
+let m ?unauthorized_handler ~key ~realm ~auth_callback () =
+  let unauthorized_handler =
+    Option.value unauthorized_handler ~default:(fun _req ->
+        Response.of_plain_text "Forbidden access" ~status:`Unauthorized
+        |> Response.add_header ("WWW-Authenticate", Auth.string_of_challenge (Basic realm))
+        |> Lwt.return)
+  in
+  let filter handler ({ Request.env; _ } as req) =
+    let open Lwt.Syntax in
+    let+ resp =
+      match Request.authorization req with
+      | None -> unauthorized_handler req
+      | Some (Other _) -> handler req
+      | Some (Basic (username, password)) ->
+        (match auth_callback ~username ~password with
+        | None -> unauthorized_handler req
+        | Some user ->
+          let env = Context.add key user env in
+          let req = { req with Request.env } in
+          handler req)
+    in
+    match resp.Response.status with
+    | `Unauthorized ->
+      Response.add_header
+        ("WWW-Authenticate", Auth.string_of_challenge (Basic realm))
+        resp
+    | _ -> resp
+  in
+  Rock.Middleware.create ~name:"Basic authentication" ~filter
+;;

--- a/opium/src/middlewares/middleware_basic_auth.mli
+++ b/opium/src/middlewares/middleware_basic_auth.mli
@@ -2,6 +2,6 @@ val m
   :  ?unauthorized_handler:Rock.Handler.t
   -> key:'a Context.key
   -> realm:string
-  -> auth_callback:(username:string -> password:string -> 'a option)
+  -> auth_callback:(username:string -> password:string -> 'a option Lwt.t)
   -> unit
   -> Rock.Middleware.t

--- a/opium/src/middlewares/middleware_basic_auth.mli
+++ b/opium/src/middlewares/middleware_basic_auth.mli
@@ -1,0 +1,7 @@
+val m
+  :  ?unauthorized_handler:Rock.Handler.t
+  -> key:'a Context.key
+  -> realm:string
+  -> auth_callback:(username:string -> password:string -> 'a option)
+  -> unit
+  -> Rock.Middleware.t

--- a/opium/src/opium.ml
+++ b/opium/src/opium.ml
@@ -9,6 +9,7 @@ module Request = Request
 module Response = Response
 module App = App
 module Route = Route
+module Auth = Auth
 module Router = Middleware_router
 
 module Handler = struct
@@ -27,4 +28,5 @@ module Middleware = struct
   let etag = Middleware_etag.m
   let method_required = Middleware_method_required.m
   let head = Middleware_head.m
+  let basic_auth = Middleware_basic_auth.m
 end

--- a/opium/src/opium.mli
+++ b/opium/src/opium.mli
@@ -237,7 +237,7 @@ module Middleware : sig
     :  ?unauthorized_handler:Rock.Handler.t
     -> key:'a Context.key
     -> realm:string
-    -> auth_callback:(username:string -> password:string -> 'a option)
+    -> auth_callback:(username:string -> password:string -> 'a option Lwt.t)
     -> unit
     -> Rock.Middleware.t
 end

--- a/opium/src/opium.mli
+++ b/opium/src/opium.mli
@@ -9,6 +9,7 @@ module Request = Request
 module Response = Response
 module App = App
 module Route = Route
+module Auth = Auth
 
 module Router : sig
   type 'action t
@@ -221,4 +222,22 @@ module Middleware : sig
       request to the handler, and removes the body of the response before sending it to
       the client. *)
   val head : Rock.Middleware.t
+
+  (** {3 [basic_auth]} *)
+
+  (** [basic_auth ?unauthorized_handler ~key ~real ~auth_callback] creates a middleware
+      that proctects handlers with an authentication mechanism.
+
+      The requests have to provide an [Authorization] header with the format
+      [Basic = <credentials>]. [auth_callback] is called with the username and password
+      extracted from the credentials. If the user does not contain a valid [Authorization]
+      header, or if the [auth_callback] returns [None], the request is redirected to
+      [unauthorized_handler] (by default, returns a "Forbidden access" message). *)
+  val basic_auth
+    :  ?unauthorized_handler:Rock.Handler.t
+    -> key:'a Context.key
+    -> realm:string
+    -> auth_callback:(username:string -> password:string -> 'a option)
+    -> unit
+    -> Rock.Middleware.t
 end

--- a/opium/src/request.ml
+++ b/opium/src/request.ml
@@ -137,6 +137,16 @@ let remove_cookie key t =
 let content_type t = header "Content-Type" t
 let set_content_type s t = add_header ("Content-Type", s) t
 
+let authorization t =
+  let s = header "Authorization" t in
+  Option.map Auth.credential_of_string s
+;;
+
+let set_authorization cred t =
+  let s = Auth.string_of_credential cred in
+  add_header ("Authorization", s) t
+;;
+
 let to_multipart_form_data
     ?(callback = fun ~name:_ ~filename:_ _line -> Lwt.return_unit)
     t

--- a/opium/src/request.mli
+++ b/opium/src/request.mli
@@ -424,6 +424,17 @@ val content_type : t -> string option
     [Content-Type] set to [content_type]. *)
 val set_content_type : string -> t -> t
 
+(** {3 [authorization]} *)
+
+(** [authorization t] returns the value of the header [Authorization] of the request [t]. *)
+val authorization : t -> Auth.Credential.t option
+
+(** {3 [set_authorization]} *)
+
+(** [set_authorization authorization t] returns a copy of [t] with the value of the header
+    [Authorization] set to [authorization]. *)
+val set_authorization : Auth.Credential.t -> t -> t
+
 (** {2 Cookies} *)
 
 (** {3 [cookie]} *)


### PR DESCRIPTION
This PR adds a `basic_auth` middleware to protect handlers with an authentication mechanism.

It also adds an `Auth` module with functions to encode/decode `Authorization` header values.

The `basic_auth` middleware has type

```ocaml
val basic_auth
  :  ?unauthorized_handler:Rock.Handler.t
  -> key:'a Context.key
  -> realm:string
  -> auth_callback:(username:string -> password:string -> 'a option)
  -> unit
  -> Rock.Middleware.t
```

I believe it is flexible enough and will allow users to build their own authentication logic, without having to deal with the boilerplate logic.

**TODO**

- [x] Document the `Auth` module
- [ ] Support `Bearer`, and maybe cookie?