### PR TITLE
Fix cookie parsing by trimming cookie key

### DIFF
--- a/opium/src/body.ml
+++ b/opium/src/body.ml
@@ -1,1 +1,51 @@
 include Rock.Body
+
+let log_src = Logs.Src.create "opium.handler_serve"
+
+module Log = (val Logs.src_log log_src : Logs.LOG)
+
+exception Isnt_a_file
+
+let of_file ?(local_path = "") fname =
+  let open Lwt.Syntax in
+  (* TODO: allow buffer size to be configurable *)
+  let bufsize = 4096 in
+  let fname = Filename.concat local_path fname in
+  Lwt.catch
+    (fun () ->
+      let* s = Lwt_unix.stat fname in
+      let* () =
+        if Unix.(s.st_kind <> S_REG) then Lwt.fail Isnt_a_file else Lwt.return_unit
+      in
+      let* ic =
+        Lwt_io.open_file
+          ~buffer:(Lwt_bytes.create bufsize)
+          ~flags:[ O_RDONLY ]
+          ~mode:Lwt_io.input
+          fname
+      in
+      let+ size = Lwt_io.length ic in
+      let stream =
+        Lwt_stream.from (fun () ->
+            Lwt.catch
+              (fun () ->
+                let+ b = Lwt_io.read ~count:bufsize ic in
+                match b with
+                | "" -> None
+                | buf -> Some buf)
+              (fun exn ->
+                Log.warn (fun m ->
+                    m "Error while reading file %s. %s" fname (Printexc.to_string exn));
+                Lwt.return_none))
+      in
+      Lwt.on_success (Lwt_stream.closed stream) (fun () ->
+          Lwt.async (fun () -> Lwt_io.close ic));
+      Ok (of_stream ~length:size stream))
+    (fun e ->
+      match e with
+      | Isnt_a_file | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return (Error `Not_found)
+      | exn ->
+        Logs.err (fun m ->
+            m "Unknown error while serving file %s. %s" fname (Printexc.to_string exn));
+        Lwt.fail exn)
+;;

--- a/opium/src/body.mli
+++ b/opium/src/body.mli
@@ -25,6 +25,11 @@ val of_bigstring : Bigstringaf.t -> t
 (** [of_stream] takes a [string Lwt_stream.t] and creates a HTTP body from it. *)
 val of_stream : ?length:Int64.t -> string Lwt_stream.t -> t
 
+(** [of_file ?local_path fname] creates a response body by reading the file with the name
+    [fname] at the path [local_path]. If no [local_path] is given, fname must contain the
+    complete path of the file. *)
+val of_file : ?local_path:string -> string -> (t, [> `Not_found ]) result Lwt.t
+
 (** [empty] represents a body of size 0L. *)
 val empty : t
 

--- a/opium/src/cookie.ml
+++ b/opium/src/cookie.ml
@@ -489,7 +489,7 @@ let cookie_of_header ?signed_with cookie_key (key, value) =
     String.split_on_char ';' value
     |> List.map (Astring.String.cut ~sep:"=")
     |> List.find_map (function
-           | Some (k, value) when k = cookie_key ->
+           | Some (k, value) when String.trim k = cookie_key ->
              let value =
                match signed_with with
                | Some signer -> String.trim value |> Signer.unsign signer

--- a/opium/src/middlewares/middleware_static_unix.ml
+++ b/opium/src/middlewares/middleware_static_unix.ml
@@ -1,55 +1,8 @@
-let log_src =
-  Logs.Src.create ~doc:"Opium middleware to server static files" "opium.static_server"
-;;
-
-module Log = (val Logs.src_log log_src : Logs.LOG)
-
-exception Isnt_a_file
-
-let read ~local_path fname =
-  let open Lwt.Syntax in
-  (* TODO: allow buffer size to be configurable *)
-  let bufsize = 4096 in
-  let fname = Filename.concat local_path fname in
-  Lwt.catch
-    (fun () ->
-      let* s = Lwt_unix.stat fname in
-      let* () =
-        if Unix.(s.st_kind <> S_REG) then Lwt.fail Isnt_a_file else Lwt.return_unit
-      in
-      let* ic =
-        Lwt_io.open_file
-          ~buffer:(Lwt_bytes.create bufsize)
-          ~flags:[ O_RDONLY ]
-          ~mode:Lwt_io.input
-          fname
-      in
-      let+ size = Lwt_io.length ic in
-      let stream =
-        Lwt_stream.from (fun () ->
-            Lwt.catch
-              (fun () ->
-                let+ b = Lwt_io.read ~count:bufsize ic in
-                match b with
-                | "" -> None
-                | buf -> Some buf)
-              (fun exn ->
-                Log.warn (fun m ->
-                    m "Error while reading file %s. %s" fname (Printexc.to_string exn));
-                Lwt.return_none))
-      in
-      Lwt.on_success (Lwt_stream.closed stream) (fun () ->
-          Lwt.async (fun () -> Lwt_io.close ic));
-      Ok (Body.of_stream ~length:size stream))
-    (fun e ->
-      match e with
-      | Isnt_a_file | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return (Error `Not_found)
-      | exn ->
-        Logs.err (fun m ->
-            m "Unknown error while serving file %s. %s" fname (Printexc.to_string exn));
-        Lwt.fail exn)
-;;
-
 let m ~local_path ?uri_prefix ?headers ?etag_of_fname () =
-  Middleware_static.m ~read:(read ~local_path) ?uri_prefix ?headers ?etag_of_fname ()
+  Middleware_static.m
+    ~read:(Body.of_file ~local_path)
+    ?uri_prefix
+    ?headers
+    ?etag_of_fname
+    ()
 ;;

--- a/opium/src/response.mli
+++ b/opium/src/response.mli
@@ -238,6 +238,23 @@ val of_svg
   -> [ `Svg ] Tyxml_svg.elt
   -> t
 
+(** {3 [of_file]} *)
+
+(** [of_file ?version ?reason ?headers ?env fname] creates a new response from a file
+    [fname] by reading its content and streaming the response.
+
+    The content type of the response will be set automatically based on the file name
+    [fname]. You can override it by providing your own "Content-Type" header.
+
+    {3 Example} *)
+val of_file
+  :  ?version:Version.t
+  -> ?reason:string
+  -> ?headers:Headers.t
+  -> ?env:Context.t
+  -> string
+  -> t Lwt.t
+
 (** {3 [redirect_to]} *)
 
 (** [redirect_to ?status ?version ?reason ?headers ?env target] creates a new Redirect

--- a/opium/test/cookie.ml
+++ b/opium/test/cookie.ml
@@ -1,0 +1,32 @@
+let headers = [ "Cookie", "yummy_cookie=choco; tasty_cookie=strawberry" ]
+
+let parse_cookies_of_headers () =
+  let c1, c2 =
+    match Opium.Cookie.cookies_of_headers headers with
+    | [ c1; c2 ] -> c1, c2
+    | _ -> failwith "Unexpected number of cookies parsed"
+  in
+  Alcotest.(check (pair string string) "has cookie" ("yummy_cookie", "choco") c1);
+  Alcotest.(check (pair string string) "has cookie" ("tasty_cookie", "strawberry") c2);
+  ()
+;;
+
+let find_cookie_in_headers () =
+  let cookie = Opium.Cookie.cookie_of_headers "tasty_cookie" headers in
+  Alcotest.(
+    check
+      (option (pair string string))
+      "has cookie"
+      (Some ("tasty_cookie", "strawberry"))
+      cookie)
+;;
+
+let () =
+  Alcotest.run
+    "Cookie"
+    [ ( "parse"
+      , [ "test parse cookies of headers", `Quick, parse_cookies_of_headers
+        ; "test find cookie in headers", `Quick, find_cookie_in_headers
+        ] )
+    ]
+;;

--- a/opium/test/request.ml
+++ b/opium/test/request.ml
@@ -58,6 +58,18 @@ let () =
               let cookie_value = Request.cookie "cookie" request |> Option.get in
               check string "same values" "value" cookie_value;
               Lwt.return () )
+        ; ( "returns the second cookie with the matching key"
+          , fun () ->
+              let request =
+                Request.get "/"
+                |> Request.add_cookie ("cookie1", "value1")
+                |> Request.add_cookie ("cookie2", "value2")
+              in
+              let cookie_value1 = Request.cookie "cookie1" request |> Option.get in
+              let cookie_value2 = Request.cookie "cookie2" request |> Option.get in
+              check string "same values" "value2" cookie_value1;
+              check string "same values" "value2" cookie_value2;
+              Lwt.return () )
         ; ( "returns the cookie with the matching key and same signature"
           , fun () ->
               let request =


### PR DESCRIPTION
I am not sure how many whitespaces between cookie key value pairs in the `Cookie` header we should accept. This fixes handling multiple cookies the way most browsers do it I think.