### PR TITLE
Fix cookie header parsing by trimming cookie key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - New `Auth` module to work with `Authorization` header (#238)
 - New `basic_auth` middleware to protect handlers with a `Basic` authentication method (#238)
 
+## Fixed
+
+- Fix reading cookie values when multiple cookies are present in `Cookie` header
+
 # 0.19.0
 
 This release is a complete rewrite of the Opium's internal that switches from Cohttp to Httpaf.

--- a/opium/src/cookie.ml
+++ b/opium/src/cookie.ml
@@ -489,7 +489,7 @@ let cookie_of_header ?signed_with cookie_key (key, value) =
     String.split_on_char ';' value
     |> List.map (Astring.String.cut ~sep:"=")
     |> List.find_map (function
-           | Some (k, value) when k = cookie_key ->
+           | Some (k, value) when String.trim k = cookie_key ->
              let value =
                match signed_with with
                | Some signer -> String.trim value |> Signer.unsign signer

--- a/opium/test/cookie.ml
+++ b/opium/test/cookie.ml
@@ -1,0 +1,32 @@
+let headers = [ "Cookie", "yummy_cookie=choco; tasty_cookie=strawberry" ]
+
+let parse_cookies_of_headers () =
+  let c1, c2 =
+    match Opium.Cookie.cookies_of_headers headers with
+    | [ c1; c2 ] -> c1, c2
+    | _ -> failwith "Unexpected number of cookies parsed"
+  in
+  Alcotest.(check (pair string string) "has cookie" ("yummy_cookie", "choco") c1);
+  Alcotest.(check (pair string string) "has cookie" ("tasty_cookie", "strawberry") c2);
+  ()
+;;
+
+let find_cookie_in_headers () =
+  let cookie = Opium.Cookie.cookie_of_headers "tasty_cookie" headers in
+  Alcotest.(
+    check
+      (option (pair string string))
+      "has cookie"
+      (Some ("tasty_cookie", "strawberry"))
+      cookie)
+;;
+
+let () =
+  Alcotest.run
+    "Cookie"
+    [ ( "parse"
+      , [ "test parse cookies of headers", `Quick, parse_cookies_of_headers
+        ; "test find cookie in headers", `Quick, find_cookie_in_headers
+        ] )
+    ]
+;;

--- a/opium/test/dune
+++ b/opium/test/dune
@@ -1,4 +1,4 @@
 (tests
- (names middleware_allow_cors request response route)
+ (names middleware_allow_cors request response route cookie)
  (libraries alcotest alcotest-lwt lwt opium)
  (package opium))


### PR DESCRIPTION
I am not sure how many spaces we should allow between the key value pairs in the `Cookie` header, but this change fixes handling of multiple cookies with how the most common browser do it I think.