### PR TITLE
Handle ECONNABORTED in accept

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixed
+
+- Handle ECONNABORTED in accept (#250)
+
 # 0.20.0
 
 ## Added


### PR DESCRIPTION
I had an opium server crash with an error `Fatal error: exception Unix.Unix_error(Unix.ECONNABORTED, "accept", "")`. This PR handles this error case. 