### PR TITLE
Don't reverse splat matches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Fixed
 
 - Fix Fullsplat behavior (routes with `**`)
+- Undo splat reverse order. Now, the matches for `/*/*/*` with the url `/a/b/c` will return `["a"; "b"; "c"]`
 
 # 0.20.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixed
+
+- Fix Fullsplat behavior (routes with `**`)
+
 # 0.20.0
 
 ## Added

--- a/opium/src/route.ml
+++ b/opium/src/route.ml
@@ -82,11 +82,12 @@ let rec match_url t url ({ params; splat } as matches) =
   match t, url with
   | [], [] -> Some matches
   | [ FullSplat ], rest ->
-    let splat' = List.filter_map
-      ~f:(function
-        | `Delim -> None
-        | `Text s -> Some s)
-      rest
+    let splat' =
+      List.filter_map
+        ~f:(function
+          | `Delim -> None
+          | `Text s -> Some s)
+        rest
     in
     Some { matches with splat = List.rev splat' @ splat }
   | FullSplat :: _, _ -> assert false (* splat can't be last *)

--- a/opium/src/route.ml
+++ b/opium/src/route.ml
@@ -80,7 +80,7 @@ let to_string l =
 
 let rec match_url t url ({ params; splat } as matches) =
   match t, url with
-  | [], [] -> Some matches
+  | [], [] -> Some { matches with splat = List.rev splat }
   | [ FullSplat ], rest ->
     let splat' =
       List.filter_map
@@ -89,8 +89,8 @@ let rec match_url t url ({ params; splat } as matches) =
           | `Text s -> Some s)
         rest
     in
-    Some { matches with splat = List.rev splat' @ splat }
-  | FullSplat :: _, _ -> assert false (* splat can't be last *)
+    Some { matches with splat = splat' @ List.rev splat }
+  | FullSplat :: _, _ -> assert false (* splat can only be last *)
   | Match x :: t, `Text y :: url when x = y -> match_url t url matches
   | Slash :: t, `Delim :: url -> match_url t url matches
   | Splat :: t, `Text s :: url ->

--- a/opium/src/route.ml
+++ b/opium/src/route.ml
@@ -80,7 +80,15 @@ let to_string l =
 
 let rec match_url t url ({ params; splat } as matches) =
   match t, url with
-  | [], [] | [ FullSplat ], _ -> Some matches
+  | [], [] -> Some matches
+  | [ FullSplat ], rest ->
+    let splat' = List.filter_map
+      ~f:(function
+        | `Delim -> None
+        | `Text s -> Some s)
+      rest
+    in
+    Some { matches with splat = List.rev splat' @ splat }
   | FullSplat :: _, _ -> assert false (* splat can't be last *)
   | Match x :: t, `Text y :: url when x = y -> match_url t url matches
   | Slash :: t, `Delim :: url -> match_url t url matches

--- a/opium/test/route.ml
+++ b/opium/test/route.ml
@@ -77,6 +77,7 @@ let splat_route3 () =
       "matches"
       (Some { Route.params = []; splat = [ "123"; "splat"; "test" ] })
       matches)
+;;
 
 let test_match_2_params () =
   let r = Route.of_string "/xxx/:x/:y" in
@@ -136,19 +137,17 @@ let empty_route () =
 
 let test_double_splat () =
   let r = Route.of_string "/**" in
-  let matching_urls = [
-    "/test", ["test"];
-    "/", [];
-    "/user/123/foo/bar", ["bar"; "foo"; "123"; "user" ]
-  ] in
+  let matching_urls =
+    [ "/test", [ "test" ]; "/", []; "/user/123/foo/bar", [ "bar"; "foo"; "123"; "user" ] ]
+  in
   matching_urls
   |> List.iter (fun (u, splat) ->
-      Alcotest.(
-        check
-          (option matches_t)
-          "matches"
-          (Some { Route.params = []; splat })
-          (Route.match_url r u)))
+         Alcotest.(
+           check
+             (option matches_t)
+             "matches"
+             (Some { Route.params = []; splat })
+             (Route.match_url r u)))
 ;;
 
 let test_query_params_dont_impact_match () =

--- a/opium/test/route.ml
+++ b/opium/test/route.ml
@@ -75,7 +75,7 @@ let splat_route3 () =
     check
       (option matches_t)
       "matches"
-      (Some { Route.params = []; splat = [ "123"; "splat"; "test" ] })
+      (Some { Route.params = []; splat = [ "test"; "splat"; "123" ] })
       matches)
 ;;
 
@@ -138,7 +138,7 @@ let empty_route () =
 let test_double_splat () =
   let r = Route.of_string "/**" in
   let matching_urls =
-    [ "/test", [ "test" ]; "/", []; "/user/123/foo/bar", [ "bar"; "foo"; "123"; "user" ] ]
+    [ "/test", [ "test" ]; "/", []; "/user/123/foo/bar", [ "user"; "123"; "foo"; "bar" ] ]
   in
   matching_urls
   |> List.iter (fun (u, splat) ->


### PR DESCRIPTION
The routes `"/**"` and `"/*/*/*"` when matched on the url `"/1/2/3"` will return splat values `["3"; "2"; "1"]`. This PR undoes the reversing so the splat values are `["1"; "2"; "3"]` as you would expect.