### PR TITLE
Remove unused open from example

### DIFF
--- a/opium/doc/index.mld
+++ b/opium/doc/index.mld
@@ -54,7 +54,6 @@ let greet req =
   Printf.sprintf "Hello, %s" name |> Response.of_plain_text |> Lwt.return
 
 let () =
-  let open App in
   App.empty
   |> App.get "/" hello
   |> App.get "/greet/:name" greet


### PR DESCRIPTION
With this line in the code, I got the following error:
```
10 |   let open App in
           ^^^^^^^^
Error (warning 33 [unused-open]): unused open Opium.App.
```