### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,5 +200,5 @@ For example:
 
 ```
 # run in debug mode on port 9000
-$ dune exec dune build example/simple_middleware/main.exe -- -p 9000 -d
+$ dune exec example/simple_middleware/main.exe -- -p 9000 -d
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ $ dune build example/simple_middleware/main.ml
 ```
 
 Here we also use the ability of Opium to generate a cmdliner term to run your
-app. Run your executable with `-h` to see the options that are available to you.
+app. Run your executable with `--help` to see the options that are available to you.
 For example:
 
 ```


### PR DESCRIPTION
Fix typo in dune exec command line. This fixes
issue https://github.com/rgrinberg/opium/issues/272 
