### PR TITLE
Upgrade packages, replace mirage-crypto hashes with digestif

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,3 @@
-version = 0.19.0
 profile = janestreet
 parse-docstrings = true
 wrap-comments = true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,12 @@
 
 - Fix Fullsplat behavior (routes with `**`)
 - Undo splat reverse order. Now, the matches for `/*/*/*` with the url `/a/b/c` will return `["a"; "b"; "c"]`
+- deprecated `Term` commands
 
 ## Changed
 
 - Update various opium-testing apis to avoid raising warning 16
+- replacing `mirage-crypto` with `digestif`, because `mirage-crypto` doesn't provide `md5` and `sha1` anymore
 
 # 0.20.0
 

--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ $ dune build example/simple_middleware/main.ml
 ```
 
 Here we also use the ability of Opium to generate a cmdliner term to run your
-app. Run your executable with `--help` to see the options that are available to you.
+app. Run your executable with `-h` to see the options that are available to you.
 For example:
 
 ```
 # run in debug mode on port 9000
-$ dune exec example/simple_middleware/main.exe -- -p 9000 -d
+$ dune exec dune build example/simple_middleware/main.exe -- -p 9000 -d
 ```

--- a/benchmark/src/httpaf.ml
+++ b/benchmark/src/httpaf.ml
@@ -47,11 +47,11 @@ let benchmark =
 let error_handler ?request:_ error start_response =
   let response_body = start_response Headers.empty in
   (match error with
-  | `Exn exn ->
-    Body.write_string response_body (Printexc.to_string exn);
-    Body.write_string response_body "\n"
-  | #Status.standard as error ->
-    Body.write_string response_body (Status.default_reason_phrase error));
+   | `Exn exn ->
+     Body.write_string response_body (Printexc.to_string exn);
+     Body.write_string response_body "\n"
+   | #Status.standard as error ->
+     Body.write_string response_body (Status.default_reason_phrase error));
   Body.close_writer response_body
 ;;
 
@@ -61,11 +61,11 @@ let () =
   let request_handler _ = benchmark in
   let error_handler _ = error_handler in
   Lwt.async (fun () ->
-      Lwt_io.establish_server_with_client_socket
-        ~backlog:11_000
-        listen_address
-        (Server.create_connection_handler ~request_handler ~error_handler)
-      >>= fun _server -> Lwt.return_unit);
+    Lwt_io.establish_server_with_client_socket
+      ~backlog:11_000
+      listen_address
+      (Server.create_connection_handler ~request_handler ~error_handler)
+    >>= fun _server -> Lwt.return_unit);
   let forever, _ = Lwt.wait () in
   Lwt_main.run forever
 ;;

--- a/dune-project
+++ b/dune-project
@@ -18,9 +18,9 @@
 (package
  (name rock)
  (synopsis
-   "Minimalist framework to build extensible HTTP servers and clients")
+  "Minimalist framework to build extensible HTTP servers and clients")
  (description
-   "Rock is a Unix indpendent API to build extensible HTTP servers and clients. It provides building blocks such as middlewares and handlers (a.k.a controllers).")
+  "Rock is a Unix indpendent API to build extensible HTTP servers and clients. It provides building blocks such as middlewares and handlers (a.k.a controllers).")
  (depends
   (ocaml
    (>= 4.08))
@@ -37,7 +37,7 @@
  (name opium)
  (synopsis "OCaml web framework")
  (description
-   "Opium is a web framework for OCaml that provides everything you need to build safe, fast and extensible web applications.")
+  "Opium is a web framework for OCaml that provides everything you need to build safe, fast and extensible web applications.")
  (depends
   (ocaml
    (>= 4.08))
@@ -54,7 +54,7 @@
   magic-mime
   yojson
   tyxml
-  mirage-crypto
+  digestif
   (base64
    (>= 3.0.0))
   astring
@@ -71,7 +71,7 @@
  (name opium-testing)
  (synopsis "Testing library for Opium")
  (description
-   "A library that provides helpers to easily test your Opium applications.")
+  "A library that provides helpers to easily test your Opium applications.")
  (depends
   (ocaml
    (>= 4.08))
@@ -85,7 +85,7 @@
  (name opium-graphql)
  (synopsis "Run GraphQL servers with Opium")
  (description
-   "This package allows you to execute Opium requests against GraphQL schemas built with `graphql`.")
+  "This package allows you to execute Opium requests against GraphQL schemas built with `graphql`.")
  (depends
   (ocaml
    (>= 4.08))

--- a/example/file_upload/main.ml
+++ b/example/file_upload/main.ml
@@ -32,76 +32,76 @@ let index_view ?(success = false) () =
   layout
     ~title:"Opium file upload"
     [ (if success
-      then
-        div
-          ~a:[ a_class [ "mx-auto mt-16 max-w-lg rounded-md bg-green-50 p-4" ] ]
-          [ div
-              ~a:[ a_class [ "flex" ] ]
-              [ div
-                  ~a:[ a_class [ "flex-shrink-0" ] ]
-                  [ svg
-                      ~a:
-                        [ Tyxml.Svg.a_class [ "h-5 w-5 text-green-400" ]
-                        ; Tyxml.Svg.a_viewBox (0., 0., 20., 20.)
-                        ; Tyxml.Svg.a_fill `CurrentColor
-                        ]
-                      [ Tyxml.Svg.path
-                          ~a:
-                            [ a_svg_custom "fill-rule" "evenodd"
-                            ; Tyxml.Svg.a_d
-                                "M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 \
-                                 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 \
-                                 1.414l2 2a1 1 0 001.414 0l4-4z"
-                            ; a_svg_custom "clip-rule" "evenodd"
-                            ]
-                          []
-                      ]
-                  ]
-              ; div
-                  ~a:[ a_class [ "ml-3" ] ]
-                  [ p
-                      ~a:[ a_class [ "text-sm leading-5 font-medium text-green-800" ] ]
-                      [ txt "Successfully uploaded" ]
-                  ]
-              ; div
-                  ~a:[ a_class [ "ml-auto pl-3" ] ]
-                  [ div
-                      ~a:[ a_class [ "-mx-1.5 -my-1.5" ] ]
-                      [ button
-                          ~a:
-                            [ a_class
-                                [ "inline-flex rounded-md p-1.5 text-green-500 \
-                                   hover:bg-green-100 focus:outline-none \
-                                   focus:bg-green-100 transition ease-in-out \
-                                   duration-150"
-                                ]
-                            ; a_aria "label" [ "Dismiss" ]
-                            ]
-                          [ svg
-                              ~a:
-                                [ Tyxml.Svg.a_class [ "h-5 w-5" ]
-                                ; Tyxml.Svg.a_viewBox (0., 0., 20., 20.)
-                                ; Tyxml.Svg.a_fill `CurrentColor
-                                ]
-                              [ Tyxml.Svg.path
-                                  ~a:
-                                    [ a_svg_custom "fill-rule" "evenodd"
-                                    ; Tyxml.Svg.a_d
-                                        "M4.293 4.293a1 1 0 011.414 0L10 \
-                                         8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 \
-                                         10l4.293 4.293a1 1 0 01-1.414 1.414L10 \
-                                         11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 \
-                                         10 4.293 5.707a1 1 0 010-1.414z"
-                                    ; a_svg_custom "clip-rule" "evenodd"
-                                    ]
-                                  []
-                              ]
-                          ]
-                      ]
-                  ]
-              ]
-          ]
-      else div [])
+       then
+         div
+           ~a:[ a_class [ "mx-auto mt-16 max-w-lg rounded-md bg-green-50 p-4" ] ]
+           [ div
+               ~a:[ a_class [ "flex" ] ]
+               [ div
+                   ~a:[ a_class [ "flex-shrink-0" ] ]
+                   [ svg
+                       ~a:
+                         [ Tyxml.Svg.a_class [ "h-5 w-5 text-green-400" ]
+                         ; Tyxml.Svg.a_viewBox (0., 0., 20., 20.)
+                         ; Tyxml.Svg.a_fill `CurrentColor
+                         ]
+                       [ Tyxml.Svg.path
+                           ~a:
+                             [ a_svg_custom "fill-rule" "evenodd"
+                             ; Tyxml.Svg.a_d
+                                 "M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 \
+                                  00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 \
+                                  1.414l2 2a1 1 0 001.414 0l4-4z"
+                             ; a_svg_custom "clip-rule" "evenodd"
+                             ]
+                           []
+                       ]
+                   ]
+               ; div
+                   ~a:[ a_class [ "ml-3" ] ]
+                   [ p
+                       ~a:[ a_class [ "text-sm leading-5 font-medium text-green-800" ] ]
+                       [ txt "Successfully uploaded" ]
+                   ]
+               ; div
+                   ~a:[ a_class [ "ml-auto pl-3" ] ]
+                   [ div
+                       ~a:[ a_class [ "-mx-1.5 -my-1.5" ] ]
+                       [ button
+                           ~a:
+                             [ a_class
+                                 [ "inline-flex rounded-md p-1.5 text-green-500 \
+                                    hover:bg-green-100 focus:outline-none \
+                                    focus:bg-green-100 transition ease-in-out \
+                                    duration-150"
+                                 ]
+                             ; a_aria "label" [ "Dismiss" ]
+                             ]
+                           [ svg
+                               ~a:
+                                 [ Tyxml.Svg.a_class [ "h-5 w-5" ]
+                                 ; Tyxml.Svg.a_viewBox (0., 0., 20., 20.)
+                                 ; Tyxml.Svg.a_fill `CurrentColor
+                                 ]
+                               [ Tyxml.Svg.path
+                                   ~a:
+                                     [ a_svg_custom "fill-rule" "evenodd"
+                                     ; Tyxml.Svg.a_d
+                                         "M4.293 4.293a1 1 0 011.414 0L10 \
+                                          8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 \
+                                          10l4.293 4.293a1 1 0 01-1.414 1.414L10 \
+                                          11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 \
+                                          10 4.293 5.707a1 1 0 010-1.414z"
+                                     ; a_svg_custom "clip-rule" "evenodd"
+                                     ]
+                                   []
+                               ]
+                           ]
+                       ]
+                   ]
+               ]
+           ]
+       else div [])
     ; form
         ~a:[ a_enctype "multipart/form-data"; a_action "/upload"; a_method `Post ]
         [ div

--- a/example/graphql/main.ml
+++ b/example/graphql/main.ml
@@ -29,7 +29,10 @@ module Schema = struct
 
   let user : (context, user option) Graphql_lwt.Schema.typ =
     Schema.(
-      obj "user" ~doc:"A user in the system" ~fields:(fun _ ->
+      obj
+        "user"
+        ~doc:"A user in the system"
+        ~fields:
           [ field
               "id"
               ~doc:"Unique user identifier"
@@ -46,7 +49,7 @@ module Schema = struct
               ~typ:(non_null role)
               ~args:Arg.[]
               ~resolve:(fun _info p -> p.role)
-          ]))
+          ])
   ;;
 
   let schema =

--- a/example/rock_server/main.ml
+++ b/example/rock_server/main.ml
@@ -59,10 +59,10 @@ let run () =
       fd
   in
   Lwt.async (fun () ->
-      let* _ =
-        Lwt_io.establish_server_with_client_socket listen_address connection_handler
-      in
-      Lwt.return_unit);
+    let* _ =
+      Lwt_io.establish_server_with_client_socket listen_address connection_handler
+    in
+    Lwt.return_unit);
   let forever, _ = Lwt.wait () in
   Lwt_main.run forever
 ;;

--- a/opium-graphql/src/opium_graphql.ml
+++ b/opium-graphql/src/opium_graphql.ml
@@ -139,9 +139,8 @@ let make_handler
 let graphiql_etag =
   Asset.read "graphiql.html"
   |> Option.get
-  |> Cstruct.of_string
-  |> Mirage_crypto.Hash.digest `MD5
-  |> Cstruct.to_string
+  |> Digestif.MD5.digest_string
+  |> Digestif.MD5.to_raw_string
   |> Base64.encode_exn
 ;;
 

--- a/opium-graphql/test/request_test.ml
+++ b/opium-graphql/test/request_test.ml
@@ -7,10 +7,9 @@ let schema =
           "hello"
           ~typ:(non_null string)
           ~args:Arg.[ arg "name" ~typ:string ]
-          ~resolve:
-            (fun _ () -> function
-              | None -> "world"
-              | Some name -> name)
+          ~resolve:(fun _ () -> function
+            | None -> "world"
+            | Some name -> name)
       ])
 ;;
 
@@ -84,12 +83,12 @@ let suite =
           Opium.Body.of_string
             (Yojson.Safe.to_string
                (`Assoc
-                 [ ( "query"
-                   , `String
-                       "query A { hello(name: \"world\") } query B { hello(name: \
-                        \"fail\") }" )
-                 ; "operationName", `String "A"
-                 ]))
+                   [ ( "query"
+                     , `String
+                         "query A { hello(name: \"world\") } query B { hello(name: \
+                          \"fail\") }" )
+                   ; "operationName", `String "A"
+                   ]))
         in
         test_case
           ~req:(Opium.Request.make ~headers:json_content_type ~body default_uri `POST)
@@ -101,11 +100,11 @@ let suite =
           Opium.Body.of_string
             (Yojson.Safe.to_string
                (`Assoc
-                 [ ( "query"
-                   , `String
-                       "query A { hello(name: \"world\") } query B { hello(name: \
-                        \"fail\") }" )
-                 ]))
+                   [ ( "query"
+                     , `String
+                         "query A { hello(name: \"world\") } query B { hello(name: \
+                          \"fail\") }" )
+                   ]))
         in
         let query = Some [ "operationName", [ "A" ] ] in
         let uri = Uri.with_uri ~query (Uri.of_string default_uri) in
@@ -124,9 +123,9 @@ let suite =
           Opium.Body.of_string
             (Yojson.Safe.to_string
                (`Assoc
-                 [ "query", `String "query A($name: String!) { hello(name: $name) }"
-                 ; "variables", `Assoc [ "name", `String "world" ]
-                 ]))
+                   [ "query", `String "query A($name: String!) { hello(name: $name) }"
+                   ; "variables", `Assoc [ "name", `String "world" ]
+                   ]))
         in
         test_case
           ~req:(Opium.Request.make ~headers:json_content_type ~body default_uri `POST)
@@ -138,7 +137,7 @@ let suite =
           Opium.Body.of_string
             (Yojson.Safe.to_string
                (`Assoc
-                 [ "query", `String "query A($name: String!) { hello(name: $name) }" ]))
+                   [ "query", `String "query A($name: String!) { hello(name: $name) }" ]))
         in
         let query =
           Some [ "operationName", [ "A" ]; "variables", [ "{\"name\":\"world\"}" ] ]

--- a/opium.opam
+++ b/opium.opam
@@ -23,7 +23,7 @@ depends: [
   "magic-mime"
   "yojson"
   "tyxml"
-  "mirage-crypto"
+  "digestif"
   "base64" {>= "3.0.0"}
   "astring"
   "re"

--- a/opium/src/app.ml
+++ b/opium/src/app.ml
@@ -189,10 +189,10 @@ let any methods route action t =
   if List.length methods = 0
   then
     Logs.warn (fun f ->
-        f
-          "Warning: you're using [any] attempting to bind to '%s' but your list\n\
-          \        of http methods is empty route"
-          route);
+      f
+        "Warning: you're using [any] attempting to bind to '%s' but your list of http \
+         methods is empty route"
+        route);
   let route = Route.of_string route in
   methods
   |> List.fold_left ~init:t ~f:(fun app meth -> app |> register ~meth ~route ~action)
@@ -214,11 +214,11 @@ let start app =
   let middlewares = attach_middleware app in
   setup_logger app;
   Logs.info (fun f ->
-      f
-        "Starting Opium on %s:%d%s"
-        app.host
-        app.port
-        (if app.debug then " (debug mode)" else ""));
+    f
+      "Starting Opium on %s:%d%s"
+      app.host
+      app.port
+      (if app.debug then " (debug mode)" else ""));
   run_unix
     ?backlog:app.backlog
     ~middlewares
@@ -234,12 +234,12 @@ let start_multicore app =
   let middlewares = attach_middleware app in
   setup_logger app;
   Logs.info (fun f ->
-      f
-        "Starting Opium on %s:%d with %d cores%s"
-        app.host
-        app.port
-        app.jobs
-        (if app.debug then " (debug mode)" else ""));
+    f
+      "Starting Opium on %s:%d with %d cores%s"
+      app.host
+      app.port
+      app.jobs
+      (if app.debug then " (debug mode)" else ""));
   run_unix_multicore
     ~middlewares
     ~host:app.host
@@ -263,12 +263,12 @@ let print_routes_f routes =
   Printf.printf "%d Routes:\n" (Hashtbl.length routes_tbl);
   Hashtbl.iter
     (fun key data ->
-      Printf.printf
-        "> %s (%s)\n"
-        (Route.to_string key)
-        (data
-        |> List.map ~f:(fun m -> Httpaf.Method.to_string m |> String.uppercase_ascii)
-        |> String.concat ~sep:" "))
+       Printf.printf
+         "> %s (%s)\n"
+         (Route.to_string key)
+         (data
+          |> List.map ~f:(fun m -> Httpaf.Method.to_string m |> String.uppercase_ascii)
+          |> String.concat ~sep:" "))
     routes_tbl
 ;;
 

--- a/opium/src/app.mli
+++ b/opium/src/app.mli
@@ -36,7 +36,8 @@ val not_found : (Request.t -> (Headers.t * Body.t) Lwt.t) -> builder
 
 val with_error_handler : Rock.Server_connection.error_handler -> builder
 
-(** A route is a function that returns a buidler that hooks up a handler to a url mapping *)
+(** A route is a function that returns a buidler that hooks up a handler to a url mapping
+*)
 type route = string -> Rock.Handler.t -> builder
 
 (** Method specific routes *)

--- a/opium/src/body.ml
+++ b/opium/src/body.ml
@@ -12,39 +12,39 @@ let of_file fname =
   let bufsize = 4096 in
   Lwt.catch
     (fun () ->
-      let* s = Lwt_unix.stat fname in
-      let* () =
-        if Unix.(s.st_kind <> S_REG) then Lwt.fail Isnt_a_file else Lwt.return_unit
-      in
-      let* ic =
-        Lwt_io.open_file
-          ~buffer:(Lwt_bytes.create bufsize)
-          ~flags:[ O_RDONLY ]
-          ~mode:Lwt_io.input
-          fname
-      in
-      let+ size = Lwt_io.length ic in
-      let stream =
-        Lwt_stream.from (fun () ->
-            Lwt.catch
-              (fun () ->
+       let* s = Lwt_unix.stat fname in
+       let* () =
+         if Unix.(s.st_kind <> S_REG) then Lwt.fail Isnt_a_file else Lwt.return_unit
+       in
+       let* ic =
+         Lwt_io.open_file
+           ~buffer:(Lwt_bytes.create bufsize)
+           ~flags:[ O_RDONLY ]
+           ~mode:Lwt_io.input
+           fname
+       in
+       let+ size = Lwt_io.length ic in
+       let stream =
+         Lwt_stream.from (fun () ->
+           Lwt.catch
+             (fun () ->
                 let+ b = Lwt_io.read ~count:bufsize ic in
                 match b with
                 | "" -> None
                 | buf -> Some buf)
-              (fun exn ->
+             (fun exn ->
                 Log.warn (fun m ->
-                    m "Error while reading file %s. %s" fname (Printexc.to_string exn));
+                  m "Error while reading file %s. %s" fname (Printexc.to_string exn));
                 Lwt.return_none))
-      in
-      Lwt.on_success (Lwt_stream.closed stream) (fun () ->
-          Lwt.async (fun () -> Lwt_io.close ic));
-      Some (of_stream ~length:size stream))
+       in
+       Lwt.on_success (Lwt_stream.closed stream) (fun () ->
+         Lwt.async (fun () -> Lwt_io.close ic));
+       Some (of_stream ~length:size stream))
     (fun e ->
-      match e with
-      | Isnt_a_file | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return None
-      | exn ->
-        Logs.err (fun m ->
-            m "Unknown error while serving file %s. %s" fname (Printexc.to_string exn));
-        Lwt.fail exn)
+       match e with
+       | Isnt_a_file | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return None
+       | exn ->
+         Logs.err (fun m ->
+           m "Unknown error while serving file %s. %s" fname (Printexc.to_string exn));
+         Lwt.fail exn)
 ;;

--- a/opium/src/body.mli
+++ b/opium/src/body.mli
@@ -58,10 +58,10 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the body [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** [pp_hum] formats the body [t] as an string.
 
     If the body content is a stream, the pretty printer will output the value ["<stream>"]*)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/context.ml
+++ b/opium/src/context.ml
@@ -6,8 +6,8 @@ let sexp_of_t m =
   let l =
     fold
       (fun (B (k, v)) l ->
-        let name, to_sexp = Key.info k in
-        List [ Atom name; to_sexp v ] :: l)
+         let name, to_sexp = Key.info k in
+         List [ Atom name; to_sexp v ] :: l)
       m
       []
   in

--- a/opium/src/context.mli
+++ b/opium/src/context.mli
@@ -105,4 +105,4 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp_hum] formats the request [t] as a standard HTTP request *)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/cookie.ml
+++ b/opium/src/cookie.ml
@@ -37,8 +37,8 @@ module List = struct
     | [] -> None
     | x :: l ->
       (match f x with
-      | Some _ as result -> result
-      | None -> find_map f l)
+       | Some _ as result -> result
+       | None -> find_map f l)
   ;;
 end
 
@@ -202,10 +202,10 @@ end
 
 module Cookie_map = struct
   include Map.Make (struct
-    type t = int * string
+      type t = int * string
 
-    let compare (c1, s1) (c2, s2) = if String.equal s1 s2 then 0 else Int.compare c1 c2
-  end)
+      let compare (c1, s1) (c2, s2) = if String.equal s1 s2 then 0 else Int.compare c1 c2
+    end)
 
   let filter_value (fn : 'a -> bool) (map : 'a t) = filter (fun _key v -> fn v) map
 end
@@ -222,8 +222,8 @@ module Attributes = struct
   let keep_numbers s =
     Astring.String.filter
       (fun c ->
-        let code = Char.code c in
-        if code = 45 || (code >= 48 && code <= 57) then true else false)
+         let code = Char.code c in
+         if code = 45 || (code >= 48 && code <= 57) then true else false)
       s
   ;;
 
@@ -255,9 +255,10 @@ module Attributes = struct
         |> Astring.String.drop ~max:1 ~sat:(( = ) '.')
         |> String.lowercase_ascii
       in
-      if domain = ""
-         || Astring.String.is_suffix domain ~affix:"."
-         || Astring.String.is_prefix domain ~affix:"."
+      if
+        domain = ""
+        || Astring.String.is_suffix domain ~affix:"."
+        || Astring.String.is_prefix domain ~affix:"."
       then amap
       else String_map.update "domain" (force_set domain) amap
     | key :: value when String.lowercase_ascii key |> String.trim = "expires" ->
@@ -312,13 +313,13 @@ type t =
   }
 
 let make
-    ?(expires = `Session)
-    ?(scope = Uri.empty)
-    ?(same_site = `Lax)
-    ?(secure = false)
-    ?(http_only = false)
-    ?sign_with
-    (key, value)
+      ?(expires = `Session)
+      ?(scope = Uri.empty)
+      ?(same_site = `Lax)
+      ?(secure = false)
+      ?(http_only = false)
+      ?sign_with
+      (key, value)
   =
   let value =
     match sign_with with
@@ -332,8 +333,8 @@ let maybe_unsign_with ?signer ?expires ?scope ?secure ?http_only (k, v) =
   match signer with
   | Some signer ->
     (match String.trim v |> Signer.unsign signer with
-    | Some v -> Some (make ?expires ?scope ?secure ?http_only (String.trim k, v))
-    | None -> None)
+     | Some v -> Some (make ?expires ?scope ?secure ?http_only (String.trim k, v))
+     | None -> None)
   | None -> Some (make ?expires ?scope ?secure ?http_only (String.trim k, String.trim v))
 ;;
 
@@ -341,39 +342,37 @@ let of_set_cookie_header ?signed_with ?origin:_ ((_, value) : header) =
   match Astring.String.cut ~sep:";" value with
   | None ->
     Option.bind (Astring.String.cut value ~sep:"=") (fun (k, v) ->
-        if String.trim k = "" then None else maybe_unsign_with ?signer:signed_with (k, v))
+      if String.trim k = "" then None else maybe_unsign_with ?signer:signed_with (k, v))
   | Some (cookie, attrs) ->
     Option.bind (Astring.String.cut cookie ~sep:"=") (fun (k, v) ->
-        if k = ""
-        then None
-        else (
-          let attrs =
-            String.split_on_char ';' attrs
-            |> List.map String.trim
-            |> Attributes.list_to_map
-          in
-          let expires =
-            (match
-               Attributes.String_map.find_opt "expires" attrs
-               |> Option.map (fun v -> "expires", v)
-             with
-            | Some _ as opt -> opt
-            | _ ->
-              Attributes.String_map.find_opt "max-age" attrs
-              |> Option.map (fun v -> "max-age", v))
-            |> fun o -> Option.bind o (fun a -> expires_of_tuple a)
-          in
-          let secure = Attributes.String_map.key_exists ~key:"secure" attrs in
-          let http_only = Attributes.String_map.key_exists ~key:"http_only" attrs in
-          let domain : string option = Attributes.String_map.find_opt "domain" attrs in
-          let path = Attributes.String_map.find_opt "path" attrs in
-          let scope =
-            Uri.empty
-            |> fun uri ->
-            Uri.with_host uri domain
-            |> fun uri -> Option.map (Uri.with_path uri) path |> Option.value ~default:uri
-          in
-          maybe_unsign_with ?signer:signed_with ?expires ~scope ~secure ~http_only (k, v)))
+      if k = ""
+      then None
+      else (
+        let attrs =
+          String.split_on_char ';' attrs |> List.map String.trim |> Attributes.list_to_map
+        in
+        let expires =
+          (match
+             Attributes.String_map.find_opt "expires" attrs
+             |> Option.map (fun v -> "expires", v)
+           with
+           | Some _ as opt -> opt
+           | _ ->
+             Attributes.String_map.find_opt "max-age" attrs
+             |> Option.map (fun v -> "max-age", v))
+          |> fun o -> Option.bind o (fun a -> expires_of_tuple a)
+        in
+        let secure = Attributes.String_map.key_exists ~key:"secure" attrs in
+        let http_only = Attributes.String_map.key_exists ~key:"http_only" attrs in
+        let domain : string option = Attributes.String_map.find_opt "domain" attrs in
+        let path = Attributes.String_map.find_opt "path" attrs in
+        let scope =
+          Uri.empty
+          |> fun uri ->
+          Uri.with_host uri domain
+          |> fun uri -> Option.map (Uri.with_path uri) path |> Option.value ~default:uri
+        in
+        maybe_unsign_with ?signer:signed_with ?expires ~scope ~secure ~http_only (k, v)))
 ;;
 
 let to_set_cookie_header t =
@@ -411,8 +410,8 @@ let is_expired ?now t =
   | None -> false
   | Some than ->
     (match t.expires with
-    | `Date e -> Ptime.is_earlier ~than e
-    | _ -> false)
+     | `Date e -> Ptime.is_earlier ~than e
+     | _ -> false)
 ;;
 
 let is_not_expired ?now t = not (is_expired ?now t)
@@ -428,8 +427,9 @@ let is_not_too_old ?(elapsed = 0L) t = not (is_too_old ~elapsed t)
 let has_matching_domain ~scope t =
   match Uri.host scope, Uri.host t.scope with
   | Some domain, Some cookie_domain ->
-    if String.contains cookie_domain '.'
-       && (Astring.String.is_suffix domain ~affix:cookie_domain || domain = cookie_domain)
+    if
+      String.contains cookie_domain '.'
+      && (Astring.String.is_suffix domain ~affix:cookie_domain || domain = cookie_domain)
     then true
     else false
   | _ -> true
@@ -459,15 +459,15 @@ let to_cookie_header ?now ?(elapsed = 0L) ?(scope = Uri.of_string "/") tl =
     let cookie_map : string Cookie_map.t =
       tl
       |> List.filter (fun c ->
-             is_not_expired ?now c
-             && has_matching_domain ~scope c
-             && has_matching_path ~scope c
-             && is_secure ~scope c)
+        is_not_expired ?now c
+        && has_matching_domain ~scope c
+        && has_matching_path ~scope c
+        && is_secure ~scope c)
       |> List.fold_left
            (fun m c ->
-             idx := !idx + 1;
-             let key, _value = c.value in
-             Cookie_map.update (!idx, key) (fun _ -> Some c) m)
+              idx := !idx + 1;
+              let key, _value = c.value in
+              Cookie_map.update (!idx, key) (fun _ -> Some c) m)
            Cookie_map.empty
       |> Cookie_map.filter_value (is_not_too_old ~elapsed)
       |> Cookie_map.map (fun c -> snd c.value)
@@ -488,14 +488,14 @@ let cookie_of_header ?signed_with cookie_key (key, value) =
     String.split_on_char ';' value
     |> List.map (Astring.String.cut ~sep:"=")
     |> List.find_map (function
-           | Some (k, value) when String.trim k = cookie_key ->
-             let value =
-               match signed_with with
-               | Some signer -> String.trim value |> Signer.unsign signer
-               | None -> Some (String.trim value)
-             in
-             Option.map (fun el -> String.trim k, el) value
-           | _ -> None)
+      | Some (k, value) when String.trim k = cookie_key ->
+        let value =
+          match signed_with with
+          | Some signer -> String.trim value |> Signer.unsign signer
+          | None -> Some (String.trim value)
+        in
+        Option.map (fun el -> String.trim k, el) value
+      | _ -> None)
   | _ -> None
 ;;
 
@@ -504,8 +504,8 @@ let cookie_of_headers ?signed_with cookie_key headers =
     | [] -> None
     | header :: rest ->
       (match cookie_of_header ?signed_with cookie_key header with
-      | Some cookie -> Some cookie
-      | None -> aux rest)
+       | Some cookie -> Some cookie
+       | None -> aux rest)
   in
   aux headers
 ;;
@@ -516,21 +516,21 @@ let cookies_of_header ?signed_with (key, value) =
     String.split_on_char ';' value
     |> List.map (Astring.String.cut ~sep:"=")
     |> List.filter_map (function
-           | Some (key, value) ->
-             let value =
-               match signed_with with
-               | Some signer -> String.trim value |> Signer.unsign signer
-               | None -> Some (String.trim value)
-             in
-             Option.map (fun el -> String.trim key, el) value
-           | None -> None)
+      | Some (key, value) ->
+        let value =
+          match signed_with with
+          | Some signer -> String.trim value |> Signer.unsign signer
+          | None -> Some (String.trim value)
+        in
+        Option.map (fun el -> String.trim key, el) value
+      | None -> None)
   | _ -> []
 ;;
 
 let cookies_of_headers ?signed_with headers =
   ListLabels.fold_left headers ~init:[] ~f:(fun acc header ->
-      let cookies = cookies_of_header ?signed_with header in
-      acc @ cookies)
+    let cookies = cookies_of_header ?signed_with header in
+    acc @ cookies)
 ;;
 
 let sexp_of_t t =
@@ -540,18 +540,18 @@ let sexp_of_t t =
     [ List
         [ Atom "expires"
         ; (match t.expires with
-          | `Session -> List [ Atom "session" ]
-          | `Max_age a -> List [ Atom "max_age"; Atom (Int64.to_string a) ]
-          | `Date d -> List [ Atom "date"; Atom (Format.asprintf "%a" Ptime.pp d) ])
+           | `Session -> List [ Atom "session" ]
+           | `Max_age a -> List [ Atom "max_age"; Atom (Int64.to_string a) ]
+           | `Date d -> List [ Atom "date"; Atom (Format.asprintf "%a" Ptime.pp d) ])
         ]
     ; List [ Atom "scope"; sexp_of_string (Format.asprintf "%a" Uri.pp t.scope) ]
     ; List
         [ Atom "same_site"
         ; sexp_of_string
             (match t.same_site with
-            | `None -> "none"
-            | `Strict -> "strict"
-            | `Lax -> "lax")
+             | `None -> "none"
+             | `Strict -> "strict"
+             | `Lax -> "lax")
         ]
     ; List [ Atom "secure"; sexp_of_bool t.secure ]
     ; List [ Atom "http_only"; sexp_of_bool t.http_only ]

--- a/opium/src/cookie.ml
+++ b/opium/src/cookie.ml
@@ -65,18 +65,11 @@ module Signer = struct
     else constant_time_compare' a b 0
   ;;
 
-  let derive_key t =
-    Mirage_crypto.Hash.mac
-      `SHA1
-      ~key:(Cstruct.of_string t.secret)
-      (Cstruct.of_string t.salt)
-  ;;
+  let derive_key t = Digestif.SHA1.(hmac_string ~key:t.secret t.salt |> to_hex)
 
   let get_signature t value =
-    value
-    |> Cstruct.of_string
-    |> Mirage_crypto.Hash.mac `SHA1 ~key:(derive_key t)
-    |> Cstruct.to_string
+    Digestif.SHA1.hmac_string ~key:(derive_key t) value
+    |> Digestif.SHA1.to_raw_string
     |> Base64.encode_exn
   ;;
 

--- a/opium/src/cookie.mli
+++ b/opium/src/cookie.mli
@@ -200,4 +200,4 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the cookie [t] as an s-expression. *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/dune
+++ b/opium/src/dune
@@ -1,7 +1,7 @@
 (library
  (public_name opium)
  (libraries rock cmdliner httpaf httpaf-lwt-unix logs logs.fmt mtime.clock.os
-   ptime yojson tyxml mirage-crypto base64 astring re uri magic-mime
+   ptime yojson tyxml digestif base64 astring re uri magic-mime
    multipart-form-data))
 
 (include_subdirs unqualified)

--- a/opium/src/headers.mli
+++ b/opium/src/headers.mli
@@ -23,13 +23,14 @@
     appending each subsequent field value to the combined field value in order, separated
     by a comma.
     {i The order in which header fields with the same field name are received is therefore
-       significant to the interpretation of the combined field value}; a proxy MUST NOT
+    significant to the interpretation of the combined field value}; a proxy MUST NOT
     change the order of these field values when forwarding a message.
 
     {i Note.} Unless otherwise specified, all operations preserve header field order and
     all reference to equality on names is assumed to be case-insensitive.
 
-    See {{:https://tools.ietf.org/html/rfc7230#section-3.2} RFC7230§3.2} for more details. *)
+    See {{:https://tools.ietf.org/html/rfc7230#section-3.2} RFC7230§3.2} for more details.
+*)
 
 type t = Httpaf.Headers.t
 
@@ -49,7 +50,7 @@ val empty : t
     transmission order. The following equations should hold:
 
     - [to_list (of_list lst) = lst]
-    - [get (of_list \[("k", "v1"); ("k", "v2")\]) "k" = Some "v2"]. *)
+    - [get (of_list [("k", "v1"); ("k", "v2")]) "k" = Some "v2"]. *)
 val of_list : (name * value) list -> t
 
 (** [of_list assoc] is a collection of header fields defined by the association list
@@ -57,7 +58,7 @@ val of_list : (name * value) list -> t
     the intended trasmission order. The following equations should hold:
 
     - [to_list (of_rev_list lst) = List.rev lst]
-    - [get (of_rev_list \[("k", "v1"); ("k", "v2")\]) "k" = Some "v1"]. *)
+    - [get (of_rev_list [("k", "v1"); ("k", "v2")]) "k" = Some "v1"]. *)
 val of_rev_list : (name * value) list -> t
 
 (** [to_list t] is the association list of header fields contained in [t] in transmission
@@ -76,7 +77,8 @@ val to_rev_list : t -> (name * value) list
 val add : t -> name -> value -> t
 
 (** [add_unless_exists t name value] is a collection of header fields that is the same as
-    [t] if [t] already inclues [name], and otherwise is equivalent to [add t name value]. *)
+    [t] if [t] already inclues [name], and otherwise is equivalent to [add t name value].
+*)
 val add_unless_exists : t -> name -> value -> t
 
 (** [add_list t assoc] is a collection of header fields that is the same as [t] except
@@ -95,7 +97,7 @@ val add_list_unless_exists : t -> (name * value) list -> t
       add_list
         t
         (List.concat_map assoc ~f:(fun (name, values) ->
-             List.map values ~f:(fun value -> name, value)))
+           List.map values ~f:(fun value -> name, value)))
     ]}
 
     but is implemented more efficiently. For example,
@@ -152,8 +154,8 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the request [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** [pp_hum] formats the request [t] as a standard HTTP request *)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/import.ml
+++ b/opium/src/import.ml
@@ -13,8 +13,8 @@ module List = struct
     | [] -> None
     | x :: l ->
       (match f x with
-      | Some _ as result -> result
-      | None -> find_map ~f l)
+       | Some _ as result -> result
+       | None -> find_map ~f l)
   ;;
 
   let replace_or_add ~f to_add l =

--- a/opium/src/method.mli
+++ b/opium/src/method.mli
@@ -21,11 +21,14 @@ type standard =
     (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.2} RFC7231§4.3.2}. Safe,
         Cacheable. *)
   | `POST
-    (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.3} RFC7231§4.3.3}. Cacheable. *)
+    (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.3} RFC7231§4.3.3}. Cacheable.
+    *)
   | `PUT
-    (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.4} RFC7231§4.3.4}. Idempotent. *)
+    (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.4} RFC7231§4.3.4}. Idempotent.
+    *)
   | `DELETE
-    (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.5} RFC7231§4.3.5}. Idempotent. *)
+    (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.5} RFC7231§4.3.5}. Idempotent.
+    *)
   | `CONNECT (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.6} RFC7231§4.3.6}. *)
   | `OPTIONS
     (** {{:https://tools.ietf.org/html/rfc7231#section-4.3.7} RFC7231§4.3.7}. Safe.*)
@@ -76,4 +79,4 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the request [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/middlewares/middleware_allow_cors.ml
+++ b/opium/src/middlewares/middleware_allow_cors.ml
@@ -77,14 +77,14 @@ let options_cors_headers ~max_age ~headers ~methods request =
 ;;
 
 let m
-    ?(origins = default_origin)
-    ?(credentials = default_credentials)
-    ?(max_age = default_max_age)
-    ?(headers = default_headers)
-    ?(expose = default_expose)
-    ?(methods = default_methods)
-    ?(send_preflight_response = default_send_preflight_response)
-    ()
+      ?(origins = default_origin)
+      ?(credentials = default_credentials)
+      ?(max_age = default_max_age)
+      ?(headers = default_headers)
+      ?(expose = default_expose)
+      ?(methods = default_methods)
+      ?(send_preflight_response = default_send_preflight_response)
+      ()
   =
   let open Lwt.Syntax in
   let filter handler req =

--- a/opium/src/middlewares/middleware_basic_auth.ml
+++ b/opium/src/middlewares/middleware_basic_auth.ml
@@ -1,9 +1,9 @@
 let m ?unauthorized_handler ~key ~realm ~auth_callback () =
   let unauthorized_handler =
     Option.value unauthorized_handler ~default:(fun _req ->
-        Response.of_plain_text "Forbidden access" ~status:`Unauthorized
-        |> Response.add_header ("WWW-Authenticate", Auth.string_of_challenge (Basic realm))
-        |> Lwt.return)
+      Response.of_plain_text "Forbidden access" ~status:`Unauthorized
+      |> Response.add_header ("WWW-Authenticate", Auth.string_of_challenge (Basic realm))
+      |> Lwt.return)
   in
   let filter handler ({ Request.env; _ } as req) =
     let open Lwt.Syntax in
@@ -14,11 +14,11 @@ let m ?unauthorized_handler ~key ~realm ~auth_callback () =
       | Some (Basic (username, password)) ->
         let* user_opt = auth_callback ~username ~password in
         (match user_opt with
-        | None -> unauthorized_handler req
-        | Some user ->
-          let env = Context.add key user env in
-          let req = { req with Request.env } in
-          handler req)
+         | None -> unauthorized_handler req
+         | Some user ->
+           let env = Context.add key user env in
+           let req = { req with Request.env } in
+           handler req)
     in
     match resp.Response.status with
     | `Unauthorized ->

--- a/opium/src/middlewares/middleware_debugger.ml
+++ b/opium/src/middlewares/middleware_debugger.ml
@@ -89,11 +89,11 @@ let m =
     Lwt.catch
       (fun () -> handler req)
       (fun exn ->
-        Logs.err ~src:log_src (fun f -> f "%s" (Nifty.Exn.to_string exn));
-        let* res_string = format_error { req with body } exn in
-        let body = Body.of_string res_string in
-        Rock.Server_connection.halt
-          (Response.make ~status:`Internal_server_error ~body ()))
+         Logs.err ~src:log_src (fun f -> f "%s" (Nifty.Exn.to_string exn));
+         let* res_string = format_error { req with body } exn in
+         let body = Body.of_string res_string in
+         Rock.Server_connection.halt
+           (Response.make ~status:`Internal_server_error ~body ()))
   in
   Rock.Middleware.create ~name:"Debugger" ~filter
 ;;

--- a/opium/src/middlewares/middleware_etag.ml
+++ b/opium/src/middlewares/middleware_etag.ml
@@ -5,11 +5,8 @@ open Import
 
 let etag_of_body body =
   let encode s =
-    s
-    |> Cstruct.of_string
-    |> Mirage_crypto.Hash.digest `MD5
-    |> Cstruct.to_string
-    |> Base64.encode_exn
+    let open Digestif.MD5 in
+    s |> digest_string |> to_raw_string |> Base64.encode_exn
   in
   match body.Body.content with
   | `String s -> Some (encode s)

--- a/opium/src/middlewares/middleware_logger.ml
+++ b/opium/src/middlewares/middleware_logger.ml
@@ -81,8 +81,8 @@ let m =
     Lwt.catch
       (fun () -> respond handler req)
       (fun exn ->
-        Logs.err ~src:log_src (fun f -> f "%s" (Nifty.Exn.to_string exn));
-        Lwt.fail exn)
+         Logs.err ~src:log_src (fun f -> f "%s" (Nifty.Exn.to_string exn));
+         Lwt.fail exn)
   in
   Rock.Middleware.create ~name:"Logger" ~filter
 ;;

--- a/opium/src/middlewares/middleware_method_override.ml
+++ b/opium/src/middlewares/middleware_method_override.ml
@@ -12,8 +12,8 @@ let m =
         match method_result with
         | Some m ->
           (match Method.of_string m with
-          | (`PUT | `DELETE | `Other "PATCH") as m -> m
-          | _ -> req.meth)
+           | (`PUT | `DELETE | `Other "PATCH") as m -> m
+           | _ -> req.meth)
         | None -> req.meth
       in
       handler { req with meth = method_ }

--- a/opium/src/middlewares/middleware_router.ml
+++ b/opium/src/middlewares/middleware_router.ml
@@ -1,14 +1,14 @@
 open Import
 
 module Method_map = Map.Make (struct
-  type t = Method.t
+    type t = Method.t
 
-  let compare a b =
-    let left = String.uppercase_ascii (Method.to_string a) in
-    let right = String.uppercase_ascii (Method.to_string b) in
-    String.compare left right
-  ;;
-end)
+    let compare a b =
+      let left = String.uppercase_ascii (Method.to_string a) in
+      let right = String.uppercase_ascii (Method.to_string b) in
+      String.compare left right
+    ;;
+  end)
 
 type 'a t = (Route.t * 'a) list Method_map.t
 
@@ -33,7 +33,7 @@ let add t ~route ~meth ~action =
 let matching_endpoint endpoints meth uri =
   let endpoints = get endpoints meth in
   List.find_map endpoints ~f:(fun ep ->
-      uri |> Route.match_url (fst ep) |> Option.map (fun p -> ep, p))
+    uri |> Route.match_url (fst ep) |> Option.map (fun p -> ep, p))
 ;;
 
 module Env = struct

--- a/opium/src/middlewares/middleware_static_unix.ml
+++ b/opium/src/middlewares/middleware_static_unix.ml
@@ -8,9 +8,8 @@ let default_etag ~local_path fname =
     let* stat = Lwt_unix.stat fpath in
     let hash =
       Marshal.to_string stat.st_mtime []
-      |> Cstruct.of_string
-      |> Mirage_crypto.Hash.digest `MD5
-      |> Cstruct.to_string
+      |> Digestif.MD5.digest_string
+      |> Digestif.MD5.to_raw_string
       |> Base64.encode_exn
     in
     Lwt.return_some hash

--- a/opium/src/opium.mli
+++ b/opium/src/opium.mli
@@ -120,8 +120,7 @@ module Middleware : sig
 
   (** {3 [allow_cors]} *)
 
-  (** [allow_cors ?origins ?credentials ?max_age ?headers ?expose ?methods
-      ?send_preflight_response ()]
+  (** [allow_cors ?origins ?credentials ?max_age ?headers ?expose ?methods ?send_preflight_response ()]
       creates a middleware that adds Cross-Origin Resource Sharing (CORS) header to the
       responses. *)
   val allow_cors

--- a/opium/src/request.ml
+++ b/opium/src/request.ml
@@ -2,13 +2,13 @@ open Import
 include Rock.Request
 
 let of_string'
-    ?(content_type = "text/plain")
-    ?version
-    ?env
-    ?(headers = Headers.empty)
-    target
-    meth
-    body
+      ?(content_type = "text/plain")
+      ?version
+      ?env
+      ?(headers = Headers.empty)
+      target
+      meth
+      body
   =
   let headers = Headers.add_unless_exists headers "Content-Type" content_type in
   make ?version ~headers ~body:(Body.of_string body) ?env target meth
@@ -50,10 +50,9 @@ let to_json t =
   let open Lwt.Syntax in
   Lwt.catch
     (fun () ->
-      let+ json = to_json_exn t in
-      Some json)
-    (function
-      | _ -> Lwt.return None)
+       let+ json = to_json_exn t in
+       Some json)
+    (function _ -> Lwt.return None)
 ;;
 
 let to_plain_text t = Body.copy t.body |> Body.to_string
@@ -72,8 +71,8 @@ let add_header_or_replace (k, v) t =
   { t with
     headers =
       (if Headers.mem t.headers k
-      then Headers.replace t.headers k v
-      else Headers.add t.headers k v)
+       then Headers.replace t.headers k v
+       else Headers.add t.headers k v)
   }
 ;;
 
@@ -128,7 +127,7 @@ let remove_cookie key t =
   let cookie_header =
     cookies t
     |> List.filter_map ~f:(fun (k, v) ->
-           if not (String.equal k key) then Some (Cookie.make (k, v)) else None)
+      if not (String.equal k key) then Some (Cookie.make (k, v)) else None)
     |> Cookie.to_cookie_header
   in
   add_header_or_replace cookie_header t
@@ -148,8 +147,8 @@ let set_authorization cred t =
 ;;
 
 let to_multipart_form_data
-    ?(callback = fun ~name:_ ~filename:_ _line -> Lwt.return_unit)
-    t
+      ?(callback = fun ~name:_ ~filename:_ _line -> Lwt.return_unit)
+      t
   =
   match t.meth, content_type t with
   | `POST, Some content_type
@@ -175,8 +174,8 @@ let find_in_query key query =
   |> List.assoc_opt key
   |> fun opt ->
   Option.bind opt (function
-      | [] -> None
-      | x :: _ -> Some x)
+    | [] -> None
+    | x :: _ -> Some x)
 ;;
 
 let find_list_in_query key query =

--- a/opium/src/request.mli
+++ b/opium/src/request.mli
@@ -114,7 +114,9 @@ val delete
 
     The request initialized with:
 
-    {[ Request.of_plain_text ~body:"Hello World" "/target" `POST ]}
+    {[
+      Request.of_plain_text ~body:"Hello World" "/target" `POST
+    ]}
 
     Will be represented as:
 
@@ -122,7 +124,8 @@ val delete
 POST /target HTTP/HTTP/1.1
 Content-Type: text/plain
 
-Hello World </pre>%} *)
+Hello World </pre>%}
+*)
 val of_plain_text
   :  ?version:Version.t
   -> ?headers:Headers.t
@@ -144,7 +147,9 @@ val of_plain_text
 
     The request initialized with:
 
-    {[ Request.of_json ~body:(`Assoc [ "Hello", `String "World" ]) "/target" `POST ]}
+    {[
+      Request.of_json ~body:(`Assoc [ "Hello", `String "World" ]) "/target" `POST
+    ]}
 
     Will be represented as:
 
@@ -152,7 +157,8 @@ val of_plain_text
 POST /target HTTP/HTTP/1.1
 Content-Type: application/json
 
-{"Hello":"World"} </pre> %} *)
+{"Hello":"World"} </pre> %}
+*)
 val of_json
   :  ?version:Version.t
   -> ?headers:Headers.t
@@ -174,7 +180,9 @@ val of_json
 
     The request initialized with:
 
-    {[ Request.of_urlencoded ~body:[ "key", [ "value" ] ] "/target" `POST ]}
+    {[
+      Request.of_urlencoded ~body:[ "key", [ "value" ] ] "/target" `POST
+    ]}
 
     Will be represented as:
 
@@ -182,7 +190,8 @@ val of_json
 POST /target HTTP/HTTP/1.1
 Content-Type: application/x-www-form-urlencoded
 
-key=value </pre> %} *)
+key=value </pre> %}
+*)
 val of_urlencoded
   :  ?version:Version.t
   -> ?headers:Headers.t
@@ -207,7 +216,9 @@ val of_urlencoded
 
     [body] will be:
 
-    {[ "Hello world!" ]} *)
+    {[
+      "Hello world!"
+    ]} *)
 val to_plain_text : t -> string Lwt.t
 
 (** {3 [to_json]} *)
@@ -226,7 +237,9 @@ val to_plain_text : t -> string Lwt.t
 
     [body] will be:
 
-    {[ `Assoc [ "Hello", `String "World" ] ]} *)
+    {[
+      `Assoc [ "Hello", `String "World" ]
+    ]} *)
 val to_json : t -> Yojson.Safe.t option Lwt.t
 
 (** {3 [to_json_exn]} *)
@@ -264,7 +277,9 @@ val to_json_exn : t -> Yojson.Safe.t Lwt.t
 
     [values] will be:
 
-    {[ [ "username", [ "admin" ]; "password", [ "password" ] ] ]} *)
+    {[
+      [ "username", [ "admin" ]; "password", [ "password" ] ]
+    ]} *)
 val to_urlencoded : t -> (string * string list) list Lwt.t
 
 (** {3 [to_multipart_form_data]} *)
@@ -426,7 +441,8 @@ val set_content_type : string -> t -> t
 
 (** {3 [authorization]} *)
 
-(** [authorization t] returns the value of the header [Authorization] of the request [t]. *)
+(** [authorization t] returns the value of the header [Authorization] of the request [t].
+*)
 val authorization : t -> Auth.Credential.t option
 
 (** {3 [set_authorization]} *)
@@ -473,8 +489,7 @@ val add_cookie : ?sign_with:Cookie.Signer.t -> Cookie.value -> t -> t
 
 (** {3 [add_cookie_unless_exists]} *)
 
-(** [add_cookie_unless_exists ?sign_with ?expires ?scope ?same_site ?secure ?http_only
-    value t]
+(** [add_cookie_unless_exists ?sign_with ?expires ?scope ?same_site ?secure ?http_only value t]
     adds a cookie with value [value] to the request [t].
 
     If a cookie with the same key already exists, it will remain untouched.
@@ -517,7 +532,9 @@ val remove_cookie : string -> t -> t
 
     [username] will be:
 
-    {[ Some "admin" ]} *)
+    {[
+      Some "admin"
+    ]} *)
 val urlencoded : string -> t -> string option Lwt.t
 
 (** {3 [urlencoded_exn]} *)
@@ -530,7 +547,8 @@ val urlencoded : string -> t -> string option Lwt.t
     values associated to the key, you can use {!to_urlencoded}.
 
     If the key could not be found or if the request could not be parsed as urlencoded, an
-    [Invalid_argument] exception is raised. Use {!urlencoded} to return an option instead. *)
+    [Invalid_argument] exception is raised. Use {!urlencoded} to return an option instead.
+*)
 val urlencoded_exn : string -> t -> string Lwt.t
 
 (** {3 [urlencoded_list]} *)
@@ -539,7 +557,7 @@ val urlencoded_exn : string -> t -> string Lwt.t
     body of the request [t].
 
     If the key could not be found or if the request could not be parsed as urlencoded, an
-    empty list [\[\]] is returned instead. *)
+    empty list [[]] is returned instead. *)
 val urlencoded_list : string -> t -> string list Lwt.t
 
 (** {2 URI} *)
@@ -565,7 +583,9 @@ val urlencoded_list : string -> t -> string list Lwt.t
 
     [query] will be:
 
-    {[ Some "value" ]} *)
+    {[
+      Some "value"
+    ]} *)
 val query : string -> t -> string option
 
 (** {3 [query_exn]} *)
@@ -604,7 +624,9 @@ val query_exn : string -> t -> string
 
     [values] will be:
 
-    {[ [ "key", [ "value" ]; "key2", [ "value2" ] ] ]} *)
+    {[
+      [ "key", [ "value" ]; "key2", [ "value2" ] ]
+    ]} *)
 val query_list : t -> (string * string list) list
 
 (** {1 Utilities} *)
@@ -618,10 +640,10 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the request [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** {3 [pp_hum]} *)
 
 (** [pp_hum] formats the request [t] as a standard HTTP request *)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/response.ml
+++ b/opium/src/response.ml
@@ -2,12 +2,12 @@ open Import
 include Rock.Response
 
 let redirect_to
-    ?(status : Status.redirection = `Found)
-    ?version
-    ?reason
-    ?(headers = Headers.empty)
-    ?env
-    location
+      ?(status : Status.redirection = `Found)
+      ?version
+      ?reason
+      ?(headers = Headers.empty)
+      ?env
+      location
   =
   let headers = Headers.add_unless_exists headers "Location" location in
   make ?version ~status:(status :> Status.t) ?reason ~headers ?env ()
@@ -21,8 +21,8 @@ let add_header_or_replace (k, v) t =
   { t with
     headers =
       (if Headers.mem t.headers k
-      then Headers.replace t.headers k v
-      else Headers.add t.headers k v)
+       then Headers.replace t.headers k v
+       else Headers.add t.headers k v)
   }
 ;;
 
@@ -45,15 +45,15 @@ let remove_header key t = { t with headers = Headers.remove t.headers key }
 let cookie ?signed_with key t =
   headers "Set-Cookie" t
   |> List.find_map ~f:(fun v ->
-         match Cookie.of_set_cookie_header ?signed_with ("Set-Cookie", v) with
-         | Some (Cookie.{ value = k, _; _ } as c) when String.equal k key -> Some c
-         | _ -> None)
+    match Cookie.of_set_cookie_header ?signed_with ("Set-Cookie", v) with
+    | Some (Cookie.{ value = k, _; _ } as c) when String.equal k key -> Some c
+    | _ -> None)
 ;;
 
 let cookies ?signed_with t =
   headers "Set-Cookie" t
   |> List.filter_map ~f:(fun v ->
-         Cookie.of_set_cookie_header ?signed_with ("Set-Cookie", v))
+    Cookie.of_set_cookie_header ?signed_with ("Set-Cookie", v))
 ;;
 
 let add_cookie ?sign_with ?expires ?scope ?same_site ?secure ?http_only value t =
@@ -85,14 +85,14 @@ let add_cookie_or_replace ?sign_with ?expires ?scope ?same_site ?secure ?http_on
 ;;
 
 let add_cookie_unless_exists
-    ?sign_with
-    ?expires
-    ?scope
-    ?same_site
-    ?secure
-    ?http_only
-    (k, v)
-    t
+      ?sign_with
+      ?expires
+      ?scope
+      ?same_site
+      ?secure
+      ?http_only
+      (k, v)
+      t
   =
   let cookies = cookies t in
   if List.exists cookies ~f:(fun Cookie.{ value = cookie, _; _ } -> String.equal cookie k)
@@ -103,13 +103,13 @@ let add_cookie_unless_exists
 let remove_cookie key t = add_cookie_or_replace ~expires:(`Max_age 0L) (key, "") t
 
 let of_string'
-    ?(content_type = "text/plain")
-    ?version
-    ?status
-    ?reason
-    ?env
-    ?(headers = Headers.empty)
-    body
+      ?(content_type = "text/plain")
+      ?version
+      ?status
+      ?reason
+      ?env
+      ?(headers = Headers.empty)
+      body
   =
   let headers = Headers.add_unless_exists headers "Content-Type" content_type in
   make ?version ?status ?reason ~headers ~body:(Body.of_string body) ?env ()
@@ -203,10 +203,9 @@ let to_json t =
   let open Lwt.Syntax in
   Lwt.catch
     (fun () ->
-      let+ json = to_json_exn t in
-      Some json)
-    (function
-      | _ -> Lwt.return None)
+       let+ json = to_json_exn t in
+       Some json)
+    (function _ -> Lwt.return None)
 ;;
 
 let to_plain_text t = Body.copy t.body |> Body.to_string

--- a/opium/src/response.mli
+++ b/opium/src/response.mli
@@ -42,7 +42,9 @@ val make
 
     The response initialized with:
 
-    {[ Response.of_plain_text "Hello World" ]}
+    {[
+      Response.of_plain_text "Hello World"
+    ]}
 
     Will be represented as:
 
@@ -72,7 +74,9 @@ val of_plain_text
 
     The response initialized with:
 
-    {[ Response.of_json (`Assoc [ "Hello", `String "World" ]) ]}
+    {[
+      Response.of_json (`Assoc [ "Hello", `String "World" ])
+    ]}
 
     Will be represented as:
 
@@ -80,7 +84,8 @@ val of_plain_text
 HTTP/1.1 200 
 Content-Type: application/json
 
-{"Hello":"World"} </pre> %} *)
+{"Hello":"World"} </pre> %}
+*)
 val of_json
   :  ?version:Version.t
   -> ?status:Status.t
@@ -125,7 +130,8 @@ Content-Type: text/html; charset=utf-8
 &lt;!DOCTYPE html&gt;
 &lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot;&gt;&lt;head&gt;&lt;title&gt;Title&lt;/title&gt;&lt;/head&gt;
  &lt;body&gt;&lt;h1&gt;Hello World!&lt;/h1&gt;&lt;/body&gt;
-&lt;/html&gt; </pre> %} *)
+&lt;/html&gt; </pre> %}
+*)
 val of_html
   :  ?version:Version.t
   -> ?status:Status.t
@@ -171,7 +177,8 @@ Content-Type: application/xml charset=utf-8
 
 &lt;note&gt;&lt;to&gt;Tove&lt;/to&gt;&lt;from&gt;Jani&lt;/from&gt;&lt;heading&gt;Reminder&lt;/heading&gt;
  &lt;body&gt;Don't forget me this weekend!&lt;/body&gt;
-&lt;/note&gt; </pre> %} *)
+&lt;/note&gt; </pre> %}
+*)
 val of_xml
   :  ?version:Version.t
   -> ?status:Status.t
@@ -227,7 +234,8 @@ Content-Type: image/svg+xml
 &lt;svg xmlns=&quot;http://www.w3.org/2000/svg&quot;
  xmlns:xlink=&quot;http://www.w3.org/1999/xlink&quot;&gt;
  &lt;circle cx=&quot;50&quot; cy=&quot;50&quot; r=&quot;40&quot; fill=&quot;black&quot;&gt;&lt;/circle&gt;
-&lt;/svg&gt; </pre> %} *)
+&lt;/svg&gt; </pre> %}
+*)
 val of_svg
   :  ?version:Version.t
   -> ?status:Status.t
@@ -266,7 +274,9 @@ val of_file
 
     The response initialized with:
 
-    {[ Response.redirect_to "/redirected" ]}
+    {[
+      Response.redirect_to "/redirected"
+    ]}
 
     Will be represented as:
 
@@ -302,7 +312,9 @@ val redirect_to
 
     [body] will be:
 
-    {[ `Assoc [ "Hello", `String "World" ] ]} *)
+    {[
+      `Assoc [ "Hello", `String "World" ]
+    ]} *)
 val to_json : t -> Yojson.Safe.t option Lwt.t
 
 (** {3 [to_json_exn]} *)
@@ -326,7 +338,9 @@ val to_json_exn : t -> Yojson.Safe.t Lwt.t
 
     [body] will be:
 
-    {[ "Hello world!" ]} *)
+    {[
+      "Hello world!"
+    ]} *)
 val to_plain_text : t -> string Lwt.t
 
 (** {1 Getters and Setters} *)
@@ -534,8 +548,7 @@ val add_cookie
 
 (** {3 [add_cookie_or_replace]} *)
 
-(** [add_cookie_or_replace ?sign_with ?expires ?scope ?same_site ?secure ?http_only value
-    t]
+(** [add_cookie_or_replace ?sign_with ?expires ?scope ?same_site ?secure ?http_only value t]
     adds a cookie with value [value] to the response [t]. If a cookie with the same key
     already exists, its value will be replaced with the new value of [value]. If
     [sign_with] is provided, the cookie will be signed with the given Signer. *)
@@ -552,8 +565,7 @@ val add_cookie_or_replace
 
 (** {3 [add_cookie_unless_exists]} *)
 
-(** [add_cookie_unless_exists ?sign_with ?expires ?scope ?same_site ?secure ?http_only
-    value t]
+(** [add_cookie_unless_exists ?sign_with ?expires ?scope ?same_site ?secure ?http_only value t]
     adds a cookie with value [value] to the response [t].
 
     If a cookie with the same key already exists, it will remain untouched.
@@ -587,10 +599,10 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the response [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** {3 [pp_hum]} *)
 
 (** [pp_hum] formats the response [t] as a standard HTTP response *)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/route.ml
+++ b/opium/src/route.ml
@@ -39,9 +39,9 @@ let of_list l =
   let last_i = List.length l - 1 in
   l
   |> List.mapi ~f:(fun i s ->
-         match parse_param s with
-         | FullSplat when i <> last_i -> invalid_arg "** is only allowed at the end"
-         | x -> x)
+    match parse_param s with
+    | FullSplat when i <> last_i -> invalid_arg "** is only allowed at the end"
+    | x -> x)
 ;;
 
 let split_slash_delim =
@@ -50,16 +50,16 @@ let split_slash_delim =
     path
     |> Re.split_full re
     |> List.map ~f:(function
-           | `Text s -> `Text s
-           | `Delim _ -> `Delim)
+      | `Text s -> `Text s
+      | `Delim _ -> `Delim)
 ;;
 
 let split_slash path =
   path
   |> split_slash_delim
   |> List.map ~f:(function
-         | `Text s -> s
-         | `Delim -> "/")
+    | `Text s -> s
+    | `Delim -> "/")
 ;;
 
 let of_string path = path |> split_slash |> of_list
@@ -68,11 +68,11 @@ let to_string l =
   let r =
     l
     |> List.filter_map ~f:(function
-           | Match s -> Some s
-           | Param s -> Some (":" ^ s)
-           | Splat -> Some "*"
-           | FullSplat -> Some "**"
-           | Slash -> None)
+      | Match s -> Some s
+      | Param s -> Some (":" ^ s)
+      | Splat -> Some "*"
+      | FullSplat -> Some "**"
+      | Slash -> None)
     |> String.concat ~sep:"/"
   in
   "/" ^ r

--- a/opium/src/status.ml
+++ b/opium/src/status.ml
@@ -6,23 +6,23 @@ let rec default_reason_phrase status =
   | #Httpaf.Status.standard as status -> Httpaf.Status.default_reason_phrase status
   | `Code n when n >= 400 && n <= 599 ->
     (match Httpaf.Status.of_code n with
-    | `Code 421 -> "Misdirected Request"
-    | `Code 422 -> "Unprocessable Entity"
-    | `Code 423 -> "Locked"
-    | `Code 424 -> "Failed Dependency"
-    | `Code 428 -> "Precondition Required"
-    | `Code 429 -> "Too Many Requests"
-    | `Code 431 -> "Request Header Fields Too Large"
-    | `Code 444 -> "Connection Closed Without Response"
-    | `Code 451 -> "Unavailable For Legal Reasons"
-    | `Code 499 -> "Client Closed Request"
-    | `Code 506 -> "Variant Also Negotiates"
-    | `Code 507 -> "Insufficient Storage"
-    | `Code 508 -> "Loop Detected"
-    | `Code 510 -> "Not Extended"
-    | `Code 511 -> "Network Authentication Required"
-    | `Code _ -> "Unknown Error"
-    | status -> default_reason_phrase status)
+     | `Code 421 -> "Misdirected Request"
+     | `Code 422 -> "Unprocessable Entity"
+     | `Code 423 -> "Locked"
+     | `Code 424 -> "Failed Dependency"
+     | `Code 428 -> "Precondition Required"
+     | `Code 429 -> "Too Many Requests"
+     | `Code 431 -> "Request Header Fields Too Large"
+     | `Code 444 -> "Connection Closed Without Response"
+     | `Code 451 -> "Unavailable For Legal Reasons"
+     | `Code 499 -> "Client Closed Request"
+     | `Code 506 -> "Variant Also Negotiates"
+     | `Code 507 -> "Insufficient Storage"
+     | `Code 508 -> "Loop Detected"
+     | `Code 510 -> "Not Extended"
+     | `Code 511 -> "Network Authentication Required"
+     | `Code _ -> "Unknown Error"
+     | status -> default_reason_phrase status)
   | _ -> ""
 ;;
 
@@ -148,8 +148,8 @@ let rec long_reason_phrase status =
   | `Code 511 -> "The client needs to authenticate to gain network access."
   | `Code n when n >= 400 && n <= 599 ->
     (match Httpaf.Status.of_code n with
-    | `Code _ -> "The response returned an non-standard HTTP error code."
-    | status -> long_reason_phrase status)
+     | `Code _ -> "The response returned an non-standard HTTP error code."
+     | status -> long_reason_phrase status)
   | _ -> ""
 ;;
 

--- a/opium/src/status.mli
+++ b/opium/src/status.mli
@@ -128,13 +128,16 @@ val is_informational : t -> bool
 (** [is_successful t] is true iff [t] belongs to the Successful class of status codes. *)
 val is_successful : t -> bool
 
-(** [is_redirection t] is true iff [t] belongs to the Redirection class of status codes. *)
+(** [is_redirection t] is true iff [t] belongs to the Redirection class of status codes.
+*)
 val is_redirection : t -> bool
 
-(** [is_client_error t] is true iff [t] belongs to the Client Error class of status codes. *)
+(** [is_client_error t] is true iff [t] belongs to the Client Error class of status codes.
+*)
 val is_client_error : t -> bool
 
-(** [is_server_error t] is true iff [t] belongs to the Server Error class of status codes. *)
+(** [is_server_error t] is true iff [t] belongs to the Server Error class of status codes.
+*)
 val is_server_error : t -> bool
 
 (** [is_error t] is true iff [t] belongs to the Client Error or Server Error class of
@@ -154,8 +157,8 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the request [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** [pp_hum] formats the request [t] as a standard HTTP request *)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/src/version.mli
+++ b/opium/src/version.mli
@@ -11,7 +11,8 @@
     The protocol version as a whole indicates the sender's conformance with the set of
     requirements laid out in that version's corresponding specification of HTTP.
 
-    See {{:https://tools.ietf.org/html/rfc7230#section-2.6} RFC7230§2.6} for more details. *)
+    See {{:https://tools.ietf.org/html/rfc7230#section-2.6} RFC7230§2.6} for more details.
+*)
 
 type t = Httpaf.Version.t =
   { major : int
@@ -36,8 +37,8 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the request [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** [pp_hum] formats the request [t] as a standard HTTP request *)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/opium/test/middleware_allow_cors.ml
+++ b/opium/test/middleware_allow_cors.ml
@@ -23,9 +23,11 @@ let check_response ?headers ?status res =
 let test_regular_request () =
   let open Lwt.Syntax in
   let+ res =
-    with_service ~middlewares:[ Middleware.allow_cors () ] (fun service ->
-        let req = Request.make "/" `GET in
-        service req)
+    with_service
+      ~middlewares:[ Middleware.allow_cors () ]
+      (fun service ->
+         let req = Request.make "/" `GET in
+         service req)
   in
   check_response
     ~headers:
@@ -42,13 +44,13 @@ let test_overwrite_origin () =
     with_service
       ~middlewares:[ Middleware.allow_cors ~origins:[ "http://example.com" ] () ]
       (fun service ->
-        let req =
-          Request.make
-            "/"
-            `GET
-            ~headers:(Headers.of_list [ "origin", "http://example.com" ])
-        in
-        service req)
+         let req =
+           Request.make
+             "/"
+             `GET
+             ~headers:(Headers.of_list [ "origin", "http://example.com" ])
+         in
+         service req)
   in
   check_response
     ~headers:
@@ -63,9 +65,11 @@ let test_overwrite_origin () =
 let test_return_204_for_options () =
   let open Lwt.Syntax in
   let+ res =
-    with_service ~middlewares:[ Middleware.allow_cors () ] (fun service ->
-        let req = Request.make "/" `OPTIONS in
-        service req)
+    with_service
+      ~middlewares:[ Middleware.allow_cors () ]
+      (fun service ->
+         let req = Request.make "/" `OPTIONS in
+         service req)
   in
   check_response
     ~status:`No_content
@@ -88,14 +92,14 @@ let test_allow_request_headers () =
     with_service
       ~middlewares:[ Middleware.allow_cors ~headers:[ "*" ] () ]
       (fun service ->
-        let req =
-          Request.make
-            "/"
-            `OPTIONS
-            ~headers:
-              (Headers.of_list [ "access-control-request-headers", "header-1,header-2" ])
-        in
-        service req)
+         let req =
+           Request.make
+             "/"
+             `OPTIONS
+             ~headers:
+               (Headers.of_list [ "access-control-request-headers", "header-1,header-2" ])
+         in
+         service req)
   in
   check_response
     ~status:`No_content

--- a/opium/test/request.ml
+++ b/opium/test/request.ml
@@ -10,7 +10,7 @@ let run_quick n l =
   @@ Alcotest_lwt.run
        n
        (ListLabels.map l ~f:(fun (n, l) ->
-            n, ListLabels.map l ~f:(fun (n, el) -> test_case n el)))
+          n, ListLabels.map l ~f:(fun (n, el) -> test_case n el)))
 ;;
 
 let signer =

--- a/opium/test/response.ml
+++ b/opium/test/response.ml
@@ -7,7 +7,7 @@ let run_quick n l =
   Alcotest.run
     n
     (ListLabels.map l ~f:(fun (n, l) ->
-         n, ListLabels.map l ~f:(fun (n, el) -> Alcotest.test_case n `Quick el)))
+       n, ListLabels.map l ~f:(fun (n, el) -> Alcotest.test_case n `Quick el)))
 ;;
 
 let signer =

--- a/opium/test/route.ml
+++ b/opium/test/route.ml
@@ -142,12 +142,12 @@ let test_double_splat () =
   in
   matching_urls
   |> List.iter (fun (u, splat) ->
-         Alcotest.(
-           check
-             (option matches_t)
-             "matches"
-             (Some { Route.params = []; splat })
-             (Route.match_url r u)))
+    Alcotest.(
+      check
+        (option matches_t)
+        "matches"
+        (Some { Route.params = []; splat })
+        (Route.match_url r u)))
 ;;
 
 let test_double_splat_escape () =

--- a/rock/src/body.ml
+++ b/rock/src/body.ml
@@ -89,8 +89,8 @@ let pp_hum fmt t =
     fmt
     "%s"
     (match t.content with
-    | `Empty -> ""
-    | `String s -> s
-    | `Bigstring b -> Bigstringaf.to_string b
-    | `Stream _ -> "<stream>")
+     | `Empty -> ""
+     | `String s -> s
+     | `Bigstring b -> Bigstringaf.to_string b
+     | `Stream _ -> "<stream>")
 ;;

--- a/rock/src/body.mli
+++ b/rock/src/body.mli
@@ -55,10 +55,10 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 
 (** [pp] formats the body [t] as an s-expression *)
 val pp : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]
 
 (** [pp_hum] formats the body [t] as an string.
 
     If the body content is a stream, the pretty printer will output the value ["<stream>"]*)
 val pp_hum : Format.formatter -> t -> unit
-  [@@ocaml.toplevel_printer]
+[@@ocaml.toplevel_printer]

--- a/rock/src/context.ml
+++ b/rock/src/context.ml
@@ -1,3 +1,3 @@
 include Hmap.Make (struct
-  type 'a t = string * ('a -> Sexplib0.Sexp.t)
-end)
+    type 'a t = string * ('a -> Sexplib0.Sexp.t)
+  end)

--- a/rock/src/request.ml
+++ b/rock/src/request.ml
@@ -12,12 +12,12 @@ let client_address =
 ;;
 
 let make
-    ?(version = { Httpaf.Version.major = 1; minor = 1 })
-    ?(body = Body.empty)
-    ?(env = Context.empty)
-    ?(headers = Httpaf.Headers.empty)
-    target
-    meth
+      ?(version = { Httpaf.Version.major = 1; minor = 1 })
+      ?(body = Body.empty)
+      ?(env = Context.empty)
+      ?(headers = Httpaf.Headers.empty)
+      target
+      meth
   =
   { version; target; headers; meth; body; env }
 ;;

--- a/rock/src/response.ml
+++ b/rock/src/response.ml
@@ -8,13 +8,13 @@ type t =
   }
 
 let make
-    ?(version = { Httpaf.Version.major = 1; minor = 1 })
-    ?(status = `OK)
-    ?reason
-    ?(headers = Httpaf.Headers.empty)
-    ?(body = Body.empty)
-    ?(env = Context.empty)
-    ()
+      ?(version = { Httpaf.Version.major = 1; minor = 1 })
+      ?(status = `OK)
+      ?reason
+      ?(headers = Httpaf.Headers.empty)
+      ?(body = Body.empty)
+      ?(env = Context.empty)
+      ()
   =
   { version; status; reason; headers; body; env }
 ;;

--- a/rock/src/server_connection.ml
+++ b/rock/src/server_connection.ml
@@ -33,35 +33,35 @@ let to_httpaf_error_handler handler =
       | Some req -> req.Httpaf.Request.headers
     in
     Lwt.async (fun () ->
-        let* headers, body = handler sockaddr req_headers error in
-        let headers =
-          match Body.length body with
-          | None -> headers
-          | Some l ->
-            Httpaf.Headers.add_unless_exists headers "Content-Length" (Int64.to_string l)
-        in
-        let res_body = start_response headers in
-        let+ () =
-          Lwt_stream.iter
-            (fun s -> Httpaf.Body.write_string res_body s)
-            (Body.to_stream body)
-        in
-        Httpaf.Body.close_writer res_body)
+      let* headers, body = handler sockaddr req_headers error in
+      let headers =
+        match Body.length body with
+        | None -> headers
+        | Some l ->
+          Httpaf.Headers.add_unless_exists headers "Content-Length" (Int64.to_string l)
+      in
+      let res_body = start_response headers in
+      let+ () =
+        Lwt_stream.iter
+          (fun s -> Httpaf.Body.write_string res_body s)
+          (Body.to_stream body)
+      in
+      Httpaf.Body.close_writer res_body)
   in
   error_handler
 ;;
 
 let read_httpaf_body body =
   Lwt_stream.from (fun () ->
-      let promise, wakeup = Lwt.wait () in
-      let on_eof () = Lwt.wakeup_later wakeup None in
-      let on_read buf ~off ~len =
-        let b = Bytes.create len in
-        Bigstringaf.blit_to_bytes buf ~src_off:off ~dst_off:0 ~len b;
-        Lwt.wakeup_later wakeup (Some (Bytes.unsafe_to_string b))
-      in
-      Httpaf.Body.schedule_read body ~on_eof ~on_read;
-      promise)
+    let promise, wakeup = Lwt.wait () in
+    let on_eof () = Lwt.wakeup_later wakeup None in
+    let on_read buf ~off ~len =
+      let b = Bytes.create len in
+      Bigstringaf.blit_to_bytes buf ~src_off:off ~dst_off:0 ~len b;
+      Lwt.wakeup_later wakeup (Some (Bytes.unsafe_to_string b))
+    in
+    Httpaf.Body.schedule_read body ~on_eof ~on_read;
+    promise)
 ;;
 
 let httpaf_request_to_request ?body req =
@@ -77,63 +77,63 @@ let to_httpaf_request_handler peer_addr app =
   let service = Filter.apply_all filters handler in
   fun reqd ->
     Lwt.async (fun () ->
-        let req = Httpaf.Reqd.request reqd in
-        let req_body = Httpaf.Reqd.request_body reqd in
-        let length =
-          match Httpaf.Request.body_length req with
-          | `Chunked -> None
-          | `Fixed l -> Some l
-          | `Error _ -> failwith "Bad request"
-        in
-        let body =
-          let stream = read_httpaf_body req_body in
-          Lwt.on_termination (Lwt_stream.closed stream) (fun () ->
-              Httpaf.Body.close_reader req_body);
-          Body.of_stream ?length stream
-        in
-        let write_fixed_response ~headers f status body =
-          f reqd (Httpaf.Response.create ~headers status) body;
-          Lwt.return_unit
-        in
-        let request =
-          Request.with_client_address (httpaf_request_to_request ~body req) peer_addr
-        in
-        Lwt.catch
-          (fun () ->
-            let* { Response.body; headers; status; _ } =
-              Lwt.catch
-                (fun () -> service request)
-                (function
-                  | Halt response -> Lwt.return response
-                  | exn -> Lwt.fail exn)
-            in
-            let { Body.length; _ } = body in
-            let headers =
-              match length with
-              | None ->
-                Httpaf.Headers.add_unless_exists headers "Transfer-Encoding" "chunked"
-              | Some l ->
-                Httpaf.Headers.add_unless_exists
-                  headers
-                  "Content-Length"
-                  (Int64.to_string l)
-            in
-            match body.content with
-            | `Empty ->
-              write_fixed_response ~headers Httpaf.Reqd.respond_with_string status ""
-            | `String s ->
-              write_fixed_response ~headers Httpaf.Reqd.respond_with_string status s
-            | `Bigstring b ->
-              write_fixed_response ~headers Httpaf.Reqd.respond_with_bigstring status b
-            | `Stream s ->
-              let rb =
-                Httpaf.Reqd.respond_with_streaming
-                  reqd
-                  (Httpaf.Response.create ~headers status)
-              in
-              let+ () = Lwt_stream.iter (fun s -> Httpaf.Body.write_string rb s) s in
-              Httpaf.Body.flush rb (fun () -> Httpaf.Body.close_writer rb))
-          (fun exn ->
-            Httpaf.Reqd.report_exn reqd exn;
-            Lwt.return_unit))
+      let req = Httpaf.Reqd.request reqd in
+      let req_body = Httpaf.Reqd.request_body reqd in
+      let length =
+        match Httpaf.Request.body_length req with
+        | `Chunked -> None
+        | `Fixed l -> Some l
+        | `Error _ -> failwith "Bad request"
+      in
+      let body =
+        let stream = read_httpaf_body req_body in
+        Lwt.on_termination (Lwt_stream.closed stream) (fun () ->
+          Httpaf.Body.close_reader req_body);
+        Body.of_stream ?length stream
+      in
+      let write_fixed_response ~headers f status body =
+        f reqd (Httpaf.Response.create ~headers status) body;
+        Lwt.return_unit
+      in
+      let request =
+        Request.with_client_address (httpaf_request_to_request ~body req) peer_addr
+      in
+      Lwt.catch
+        (fun () ->
+           let* { Response.body; headers; status; _ } =
+             Lwt.catch
+               (fun () -> service request)
+               (function
+                 | Halt response -> Lwt.return response
+                 | exn -> Lwt.fail exn)
+           in
+           let { Body.length; _ } = body in
+           let headers =
+             match length with
+             | None ->
+               Httpaf.Headers.add_unless_exists headers "Transfer-Encoding" "chunked"
+             | Some l ->
+               Httpaf.Headers.add_unless_exists
+                 headers
+                 "Content-Length"
+                 (Int64.to_string l)
+           in
+           match body.content with
+           | `Empty ->
+             write_fixed_response ~headers Httpaf.Reqd.respond_with_string status ""
+           | `String s ->
+             write_fixed_response ~headers Httpaf.Reqd.respond_with_string status s
+           | `Bigstring b ->
+             write_fixed_response ~headers Httpaf.Reqd.respond_with_bigstring status b
+           | `Stream s ->
+             let rb =
+               Httpaf.Reqd.respond_with_streaming
+                 reqd
+                 (Httpaf.Response.create ~headers status)
+             in
+             let+ () = Lwt_stream.iter (fun s -> Httpaf.Body.write_string rb s) s in
+             Httpaf.Body.flush rb (fun () -> Httpaf.Body.close_writer rb))
+        (fun exn ->
+           Httpaf.Reqd.report_exn reqd exn;
+           Lwt.return_unit))
 ;;


### PR DESCRIPTION
Hi @rgrinberg

When `mirage-crypto.1.0.0` was released, they added an upper bound to many other packages, including `opium`.

This PR includes the following updates:
- replacing `mirage-crypto` with `digestif` because `mirage-crypto` doesn't provide md5 and sha1 anymore
- update deprecated Term commands (see `opium/src/app.ml`
- run formatted (`make fmt`)
- README got updated by `make build`

It would be great to see a new version of `opium` in the `opam-repository`