### PR TITLE
removes the unnecessary conf-libev dependency 

### DIFF
--- a/nix/opam-selection.nix
+++ b/nix/opam-selection.nix
@@ -638,7 +638,6 @@ in
         dune-configurator dune
         cppo;
         ocaml-syntax-shims = selection.ocaml-syntax-shims or null;
-        conf-libev = selection.conf-libev or null;
         base-unix = selection.base-unix or null;
         base-threads = selection.base-threads or null;
       };


### PR DESCRIPTION
I'm trying to removing the dependency on "conf-libev" which has appeared on opium.0.20.0.

The libev library is not available on Windows (MINGW64) and is not required to compile Opium or Lwt.

This PR should solve #292 