### PR TITLE
chop query string on static resources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Make static_unix middleware derive ETag from file modification timestamp.
 - `App.debug` and `App.verbose`
 - Give access to client's sockaddr from within an Opium handler
+- Change static files middleware to remove query string from path that is looked up on disk
 
 ## Fixed
 

--- a/opium/src/middlewares/middleware_static.ml
+++ b/opium/src/middlewares/middleware_static.ml
@@ -21,6 +21,12 @@ let chop_prefix ~prefix s =
   String.sub s ~pos:(String.length prefix) ~len:String.(length s - length prefix)
 ;;
 
+let chop_query_string s =
+  match String.index_opt s '?' with
+  | Some i -> String.sub ~pos:0 ~len:i s
+  | None -> s
+;;
+
 let _add_opt_header_unless_exists headers k v =
   match headers with
   | Some h -> Httpaf.Headers.add_unless_exists h k v
@@ -35,7 +41,7 @@ let m ~read ?(uri_prefix = "/") ?headers ?etag_of_fname () =
       let local_path = req.target in
       if local_path |> is_prefix ~prefix:uri_prefix
       then (
-        let legal_path = chop_prefix local_path ~prefix:uri_prefix in
+        let legal_path = chop_prefix local_path ~prefix:uri_prefix |> chop_query_string in
         let read () = read legal_path in
         let mime_type = Magic_mime.lookup legal_path in
         let* etag =


### PR DESCRIPTION
Chop query strings like `?v=1` from requests to static content. The query string should not be included in the filename that is looked for the file on disk.

Fixes #243 